### PR TITLE
コマンド追加システムの大規模リファクタリング

### DIFF
--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -1,10 +1,12 @@
+use crate::ai::GeminiModel;
 use serenity::{
     builder::{CreateCommand, CreateCommandOption},
-    model::application::{CommandOptionType, ResolvedOption, ResolvedValue},
+    model::application::{CommandOptionType, ResolvedValue},
 };
 use std::time::Duration;
 
-use crate::{ai::GeminiModel, commands::ManamiSlashCommand, Bot};
+use crate::{commands::ManamiSlashCommand, Bot};
+use serenity::model::application::ResolvedOption;
 
 pub struct SlashCommand;
 

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -4,10 +4,32 @@ use serenity::{
 };
 use std::time::Duration;
 
-use crate::{ai::GeminiModel, Bot};
+use crate::{ai::GeminiModel, commands::ManamiSlashCommand, Bot};
+
+pub struct SlashCommand;
+
+const COMMAND_NAME: &str = "auto";
+
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "呼びかけられなくてもお返事するよ！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, options: &[ResolvedOption<'_>], bot: &Bot) -> String {
+        run(options, bot).await
+    }
+}
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("auto")
+    CreateCommand::new(COMMAND_NAME)
         .description("[sec]秒以内の連続した会話に対して、[model]を使って必ず返信するよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "model", "モデル")
@@ -24,7 +46,6 @@ pub fn register() -> CreateCommand {
                 .max_int_value(600),
         )
 }
-
 pub async fn run(option: &[ResolvedOption<'_>], bot: &Bot) -> String {
     let model = option
         .iter()

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -12,11 +12,14 @@ pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "auto";
 
-pub const AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: COMMAND_NAME,
     description: "呼びかけられなくてもお返事するよ！",
     register,
-    run: |option, bot| unimplemented!(), /*Box::pin(run(option, bot))*/
+    run: |option, bot| {
+        let opts = parse(option, bot);
+        Box::pin(async move { run_body(opts, bot).await })
+    },
     is_local_command: true,
 };
 
@@ -38,7 +41,12 @@ pub fn register() -> CreateCommand {
                 .max_int_value(600),
         )
 }
+
 pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
+    run_body(parse(option, bot), bot).await
+}
+
+fn parse(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> (GeminiModel, Duration) {
     let model = option
         .iter()
         .fold(None, |model, option| match (option.name, &option.value) {
@@ -57,6 +65,10 @@ pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
             .unwrap_or(300),
     );
 
+    (model, sec)
+}
+
+async fn run_body((model, sec): (GeminiModel, Duration), bot: &Bot) -> String {
     bot.reply_to_all_mode
         .lock()
         .unwrap()

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -28,6 +28,10 @@ impl ManamiSlashCommand for SlashCommand {
     async fn run(&self, options: &[ResolvedOption<'_>], bot: &Bot) -> String {
         run(options, bot).await
     }
+
+    fn is_local_command(&self) -> bool {
+        true
+    }
 }
 
 pub fn register() -> CreateCommand {

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -18,7 +18,7 @@ pub const SLASH_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     description: "呼びかけられなくてもお返事するよ！",
     register,
     run: |option, bot| {
-        let opts = parse(option, bot);
+        let opts = parse_options(option, bot);
         Box::pin(async move { run_body(opts, bot).await })
     },
     is_local_command: true,
@@ -44,10 +44,10 @@ pub fn register() -> CreateCommand {
 }
 
 pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
-    run_body(parse(option, bot), bot).await
+    run_body(parse_options(option, bot), bot).await
 }
 
-fn parse(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> (GeminiModel, Duration) {
+fn parse_options(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> (GeminiModel, Duration) {
     let model = option
         .iter()
         .fold(None, |model, option| match (option.name, &option.value) {

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -14,6 +14,7 @@ const COMMAND_NAME: &str = "auto";
 
 pub const SLASH_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: COMMAND_NAME,
+    usage: "/auto [model] [sec]",
     description: "呼びかけられなくてもお返事するよ！",
     register,
     run: |option, bot| {

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -5,14 +5,14 @@ use serenity::{
 };
 use std::time::Duration;
 
-use crate::{commands::StManamiSlashCommand, Bot};
+use crate::{commands::ManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
 
 pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "auto";
 
-pub const SLASH_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_AUTO_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: COMMAND_NAME,
     usage: "/auto [model] [sec]",
     description: "呼びかけられなくてもお返事するよ！",

--- a/src/commands/auto.rs
+++ b/src/commands/auto.rs
@@ -5,34 +5,20 @@ use serenity::{
 };
 use std::time::Duration;
 
-use crate::{commands::ManamiSlashCommand, Bot};
+use crate::{commands::StManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
 
 pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "auto";
 
-impl ManamiSlashCommand for SlashCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
-
-    fn description(&self) -> &'static str {
-        "呼びかけられなくてもお返事するよ！"
-    }
-
-    fn register(&self) -> CreateCommand {
-        register()
-    }
-
-    async fn run(&self, options: &[ResolvedOption<'_>], bot: &Bot) -> String {
-        run(options, bot).await
-    }
-
-    fn is_local_command(&self) -> bool {
-        true
-    }
-}
+pub const AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: COMMAND_NAME,
+    description: "呼びかけられなくてもお返事するよ！",
+    register,
+    run: |option, bot| unimplemented!(), /*Box::pin(run(option, bot))*/
+    is_local_command: true,
+};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new(COMMAND_NAME)
@@ -52,7 +38,7 @@ pub fn register() -> CreateCommand {
                 .max_int_value(600),
         )
 }
-pub async fn run(option: &[ResolvedOption<'_>], bot: &Bot) -> String {
+pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
     let model = option
         .iter()
         .fold(None, |model, option| match (option.name, &option.value) {

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -35,7 +35,7 @@ impl From<char> for BrainfuckCommand {
     }
 }
 
-pub const BF_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_BF_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "bf",
     description: "まなみはいんたぷりた？　なんだよ！",
     register,

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -5,7 +5,7 @@ use serenity::{
     model::application::{CommandOptionType, ResolvedOption, ResolvedValue},
 };
 
-use crate::commands::StManamiSlashCommand;
+use crate::commands::ManamiSlashCommand;
 
 enum BrainfuckCommand {
     MoveRight,
@@ -35,7 +35,7 @@ impl From<char> for BrainfuckCommand {
     }
 }
 
-pub const SLASH_BF_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_BF_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: "bf",
     usage: "/bf <code> [input]",
     description: "まなみはいんたぷりた？　なんだよ！",

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -5,7 +5,7 @@ use serenity::{
     model::application::{CommandOptionType, ResolvedOption, ResolvedValue},
 };
 
-use crate::{commands::ManamiSlashCommand, Bot};
+use crate::commands::StManamiSlashCommand;
 
 enum BrainfuckCommand {
     MoveRight,
@@ -34,34 +34,20 @@ impl From<char> for BrainfuckCommand {
         }
     }
 }
-pub struct SlashCommand;
 
-const COMMAND_NAME: &str = "bf";
-
-impl ManamiSlashCommand for SlashCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
-
-    fn description(&self) -> &'static str {
-        "まなみはいんたぷりた？　なんだよ！"
-    }
-
-    fn register(&self) -> CreateCommand {
-        register()
-    }
-
-    async fn run(&self, options: &[ResolvedOption<'_>], _: &Bot) -> String {
-        run(options)
-    }
-
-    fn is_local_command(&self) -> bool {
-        false
-    }
-}
+pub const BF_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: "bf",
+    description: "まなみはいんたぷりた？　なんだよ！",
+    register,
+    run: |options, _| {
+        let result = run(options);
+        Box::pin(async move { result })
+    },
+    is_local_command: false,
+};
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new(COMMAND_NAME)
+    CreateCommand::new("bf")
         .description("Brainfuckを実行するよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "code", "Brainfuckのコード")
@@ -73,7 +59,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
-pub fn run(option: &[ResolvedOption]) -> String {
+pub fn run(option: Vec<ResolvedOption>) -> String {
     let (code, input) = option.iter().fold((None, None), |(code, input), option| {
         match (option.name, &option.value) {
             ("code", ResolvedValue::String(s)) => (Some(*s), input),

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -61,6 +61,10 @@ pub fn register() -> CreateCommand {
 }
 
 pub fn run(option: Vec<ResolvedOption>) -> String {
+    run_body(parse_options(option))
+}
+
+fn parse_options(option: Vec<ResolvedOption>) -> Result<(Vec<BrainfuckCommand>, &str), &str> {
     let (code, input) = option.iter().fold((None, None), |(code, input), option| {
         match (option.name, &option.value) {
             ("code", ResolvedValue::String(s)) => (Some(*s), input),
@@ -70,10 +74,20 @@ pub fn run(option: Vec<ResolvedOption>) -> String {
     });
 
     let Some(code) = code else {
-        return "エラーだよ！".to_owned();
+        return Err("エラーだよ！");
     };
+
     let code = code.chars().map(BrainfuckCommand::from).collect::<Vec<_>>();
     let input = input.unwrap_or("");
+
+    Ok((code, input))
+}
+
+fn run_body(parsed: Result<(Vec<BrainfuckCommand>, &str), &str>) -> String {
+    let (code, input) = match parsed {
+        Ok((code, input)) => (code, input),
+        Err(err) => return err.to_owned(),
+    };
 
     let output = interpreter(code, input);
     match output {

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -37,6 +37,7 @@ impl From<char> for BrainfuckCommand {
 
 pub const SLASH_BF_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "bf",
+    usage: "/bf <code> [input]",
     description: "まなみはいんたぷりた？　なんだよ！",
     register,
     run: |options, _| {

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -5,6 +5,8 @@ use serenity::{
     model::application::{CommandOptionType, ResolvedOption, ResolvedValue},
 };
 
+use crate::{commands::ManamiSlashCommand, Bot};
+
 enum BrainfuckCommand {
     MoveRight,
     MoveLeft,
@@ -32,9 +34,30 @@ impl From<char> for BrainfuckCommand {
         }
     }
 }
+pub struct SlashCommand;
+
+const COMMAND_NAME: &str = "bf";
+
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "まなみはいんたぷりた？　なんだよ！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, options: &[ResolvedOption<'_>], _: &Bot) -> String {
+        run(options)
+    }
+}
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("bf")
+    CreateCommand::new(COMMAND_NAME)
         .description("Brainfuckを実行するよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "code", "Brainfuckのコード")

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -54,6 +54,10 @@ impl ManamiSlashCommand for SlashCommand {
     async fn run(&self, options: &[ResolvedOption<'_>], _: &Bot) -> String {
         run(options)
     }
+
+    fn is_local_command(&self) -> bool {
+        false
+    }
 }
 
 pub fn register() -> CreateCommand {

--- a/src/commands/bf.rs
+++ b/src/commands/bf.rs
@@ -7,6 +7,18 @@ use serenity::{
 
 use crate::commands::ManamiSlashCommand;
 
+pub const SLASH_BF_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
+    name: "bf",
+    usage: "/bf <code> [input]",
+    description: "まなみはいんたぷりた？　なんだよ！",
+    register,
+    run: |options, _| {
+        let result = run(options);
+        Box::pin(async move { result })
+    },
+    is_local_command: false,
+};
+
 enum BrainfuckCommand {
     MoveRight,
     MoveLeft,
@@ -34,18 +46,6 @@ impl From<char> for BrainfuckCommand {
         }
     }
 }
-
-pub const SLASH_BF_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
-    name: "bf",
-    usage: "/bf <code> [input]",
-    description: "まなみはいんたぷりた？　なんだよ！",
-    register,
-    run: |options, _| {
-        let result = run(options);
-        Box::pin(async move { result })
-    },
-    is_local_command: false,
-};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("bf")

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -1,29 +1,33 @@
-use serenity::all::ResolvedOption;
-
 use crate::commands::var::var_main;
 use crate::commands::CommandContext;
 
 use crate::commands::ManamiPrefixCommand;
-
+use serenity::all::ResolvedOption;
 pub struct PrefixCommand;
-
-const COMMAND_NAME: &str = "calc";
 
 impl ManamiPrefixCommand for PrefixCommand {
     fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
-
-    fn description(&self) -> &'static str {
-        "数式を計算するよ！"
+        &["calc"]
     }
 
     fn usage(&self) -> &'static str {
         "!calc <expr>"
     }
 
+    fn description(&self) -> &'static str {
+        "数式を計算するよ！"
+    }
+
     async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
         run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
     }
 }
 

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -1,37 +1,17 @@
 use crate::commands::var::var_main;
 use crate::commands::CommandContext;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const CALC_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "calc",
+    usage: "!calc <expr>",
+    description: "数式を計算するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: true,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["calc"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!calc <expr>"
-    }
-
-    fn description(&self) -> &'static str {
-        "数式を計算するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let reply = ctx.channel_id;
     let bot = ctx.bot;
     let expression = ctx.args().join(" ");

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -4,6 +4,7 @@ use crate::commands::CommandContext;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_CALC_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "calc",
+    alias: &[],
     usage: "!calc <expr>",
     description: "数式を計算するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -1,5 +1,31 @@
+use serenity::all::ResolvedOption;
+
 use crate::commands::var::var_main;
 use crate::commands::CommandContext;
+
+use crate::commands::ManamiPrefixCommand;
+
+pub struct PrefixCommand;
+
+const COMMAND_NAME: &str = "calc";
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "数式を計算するよ！"
+    }
+
+    fn usage(&self) -> &'static str {
+        "!calc <expr>"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+}
 
 pub async fn run(ctx: &CommandContext<'_>) {
     let reply = ctx.channel_id;

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -7,7 +7,7 @@ pub const PREFIX_CALC_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!calc <expr>",
     description: "数式を計算するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -2,7 +2,7 @@ use crate::commands::var::var_main;
 use crate::commands::CommandContext;
 
 use crate::commands::StManamiPrefixCommand;
-pub const CALC_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_CALC_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "calc",
     usage: "!calc <expr>",
     description: "数式を計算するよ！",

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -1,8 +1,8 @@
 use crate::commands::var::var_main;
 use crate::commands::CommandContext;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_CALC_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_CALC_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "calc",
     alias: &[],
     usage: "!calc <expr>",

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -2,7 +2,7 @@ use crate::calculator::{eval_from_str, val_as_str};
 use crate::commands::CommandContext;
 
 use crate::commands::StManamiPrefixCommand;
-pub const CALCSAY_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_CALCSAY_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "calcsay",
     usage: "!calcsay <expr>",
     description: "calcの結果を代筆先に送信するよ！",

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -1,8 +1,8 @@
 use crate::calculator::{eval_from_str, val_as_str};
 use crate::commands::CommandContext;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_CALCSAY_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_CALCSAY_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "calcsay",
     alias: &[],
     usage: "!calcsay <expr>",

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -4,6 +4,7 @@ use crate::commands::CommandContext;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_CALCSAY_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "calcsay",
+    alias: &[],
     usage: "!calcsay <expr>",
     description: "calcの結果を代筆先に送信するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -1,6 +1,35 @@
 use crate::calculator::{eval_from_str, val_as_str};
 use crate::commands::CommandContext;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["calcsay"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!calcsay <expr>"
+    }
+
+    fn description(&self) -> &'static str {
+        "calcの結果を代筆先に送信するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        false
+    }
+}
 pub async fn run(ctx: &CommandContext<'_>) {
     let bot = ctx.bot;
     let reply = bot.get_user_room_pointer(ctx.author_id);

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -1,36 +1,17 @@
 use crate::calculator::{eval_from_str, val_as_str};
 use crate::commands::CommandContext;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const CALCSAY_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "calcsay",
+    usage: "!calcsay <expr>",
+    description: "calcの結果を代筆先に送信するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: false,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["calcsay"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!calcsay <expr>"
-    }
-
-    fn description(&self) -> &'static str {
-        "calcの結果を代筆先に送信するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        false
-    }
-}
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let bot = ctx.bot;
     let reply = bot.get_user_room_pointer(ctx.author_id);
     let expression = ctx.args().join(" ");

--- a/src/commands/calcsay.rs
+++ b/src/commands/calcsay.rs
@@ -7,7 +7,7 @@ pub const PREFIX_CALCSAY_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!calcsay <expr>",
     description: "calcの結果を代筆先に送信するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: false,
 };

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -2,37 +2,17 @@ use crate::cclemon;
 use crate::commands::CommandContext;
 use serenity::utils::parse_user_mention;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const CCLEMON_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "cclemon",
+    usage: "!cclemon <opponent>",
+    description: "CCレモンをするよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: false,
+    is_guild_command: true,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["cclemon"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!cclemon <opponent>"
-    }
-
-    fn description(&self) -> &'static str {
-        "CCレモンをするよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        false
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let [opponent_id] = ctx.args()[..] else {
         ctx.channel_id
             .say(ctx.cache_http(), "使い方: `!cclemon <相手>`")
@@ -48,5 +28,5 @@ pub async fn run(ctx: &CommandContext<'_>) {
         return;
     };
 
-    cclemon::cclemon(ctx, (ctx.author_id, &opponent_id)).await;
+    cclemon::cclemon(&ctx, (ctx.author_id, &opponent_id)).await;
 }

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -2,6 +2,36 @@ use crate::cclemon;
 use crate::commands::CommandContext;
 use serenity::utils::parse_user_mention;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["cclemon"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!cclemon <opponent>"
+    }
+
+    fn description(&self) -> &'static str {
+        "CCレモンをするよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        false
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
 pub async fn run(ctx: &CommandContext<'_>) {
     let [opponent_id] = ctx.args()[..] else {
         ctx.channel_id

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -8,7 +8,7 @@ pub const PREFIX_CCLEMON_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!cclemon <opponent>",
     description: "CCレモンをするよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: false,
     is_guild_command: true,
 };

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -3,7 +3,7 @@ use crate::commands::CommandContext;
 use serenity::utils::parse_user_mention;
 
 use crate::commands::StManamiPrefixCommand;
-pub const CCLEMON_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_CCLEMON_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "cclemon",
     usage: "!cclemon <opponent>",
     description: "CCレモンをするよ！",

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -2,8 +2,8 @@ use crate::cclemon;
 use crate::commands::CommandContext;
 use serenity::utils::parse_user_mention;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_CCLEMON_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_CCLEMON_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "cclemon",
     alias: &[],
     usage: "!cclemon <opponent>",

--- a/src/commands/cclemon.rs
+++ b/src/commands/cclemon.rs
@@ -5,6 +5,7 @@ use serenity::utils::parse_user_mention;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_CCLEMON_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "cclemon",
+    alias: &[],
     usage: "!cclemon <opponent>",
     description: "CCレモンをするよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -1,37 +1,17 @@
 use crate::commands::CommandContext;
 use serenity::utils::MessageBuilder;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const CHANNEL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "channel",
+    usage: "!channel",
+    description: "代筆先のチャンネルを指定するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: false,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["channel"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!channel"
-    }
-
-    fn description(&self) -> &'static str {
-        "代筆先のチャンネルを指定するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        false
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let args = ctx.args();
 
     // 引数なしの場合はチャンネル一覧を表示

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -4,6 +4,7 @@ use serenity::utils::MessageBuilder;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_CHANNEL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "channel",
+    alias: &[],
     usage: "!channel",
     description: "代筆先のチャンネルを指定するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -7,7 +7,7 @@ pub const PREFIX_CHANNEL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!channel",
     description: "代筆先のチャンネルを指定するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: false,
 };

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -2,7 +2,7 @@ use crate::commands::CommandContext;
 use serenity::utils::MessageBuilder;
 
 use crate::commands::StManamiPrefixCommand;
-pub const CHANNEL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_CHANNEL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "channel",
     usage: "!channel",
     description: "代筆先のチャンネルを指定するよ！",

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -1,6 +1,36 @@
 use crate::commands::CommandContext;
 use serenity::utils::MessageBuilder;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["channel"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!channel"
+    }
+
+    fn description(&self) -> &'static str {
+        "代筆先のチャンネルを指定するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        false
+    }
+}
+
 pub async fn run(ctx: &CommandContext<'_>) {
     let args = ctx.args();
 

--- a/src/commands/channel.rs
+++ b/src/commands/channel.rs
@@ -1,8 +1,8 @@
 use crate::commands::CommandContext;
 use serenity::utils::MessageBuilder;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_CHANNEL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_CHANNEL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "channel",
     alias: &[],
     usage: "!channel",

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -3,7 +3,13 @@ use crate::commands::CommandContext;
 use crate::commands::ManamiPrefixCommand;
 pub const PREFIX_CLEAR_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "clear",
-    alias: &[],
+    alias: &[
+        "forget",
+        "全部忘れて",
+        "ぜんぶ忘れて",
+        "全部わすれて",
+        "ぜんぶわすれて",
+    ],
     usage: "!clear",
     description: "チャンネルの会話ログを忘れるよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,36 +1,16 @@
 use crate::commands::CommandContext;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const CLEAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "clear",
+    usage: "!clear",
+    description: "チャンネルの会話ログを忘れるよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: false,
+    is_guild_command: true,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["clear", "全部忘れて"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!clear"
-    }
-
-    fn description(&self) -> &'static str {
-        "チャンネルの会話ログを忘れるよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        false
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     ctx.channel_id
         .say(ctx.cache_http(), "1……2の……ポカン！")
         .await

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,7 +1,7 @@
 use crate::commands::CommandContext;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_CLEAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_CLEAR_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "clear",
     alias: &[],
     usage: "!clear",

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -12,7 +12,7 @@ pub const PREFIX_CLEAR_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     ],
     usage: "!clear",
     description: "チャンネルの会話ログを忘れるよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: false,
     is_guild_command: true,
 };

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,7 +1,7 @@
 use crate::commands::CommandContext;
 
 use crate::commands::StManamiPrefixCommand;
-pub const CLEAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_CLEAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "clear",
     usage: "!clear",
     description: "チャンネルの会話ログを忘れるよ！",

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -3,6 +3,7 @@ use crate::commands::CommandContext;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_CLEAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "clear",
+    alias: &[],
     usage: "!clear",
     description: "チャンネルの会話ログを忘れるよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,5 +1,35 @@
 use crate::commands::CommandContext;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["clear", "全部忘れて"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!clear"
+    }
+
+    fn description(&self) -> &'static str {
+        "チャンネルの会話ログを忘れるよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        false
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
 pub async fn run(ctx: &CommandContext<'_>) {
     ctx.channel_id
         .say(ctx.cache_http(), "1……2の……ポカン！")

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -18,7 +18,7 @@ pub const PREFIX_DICE_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "![n]d<m>",
     description: "m面ダイスをn回振るよ！",
-    run: |ctx, _| Box::pin(run_old(ctx)),
+    run: |ctx| Box::pin(run_old(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -51,7 +51,7 @@ impl ManamiSlashCommand for SlashCommand {
     }
 
     fn description(&self) -> &'static str {
-        "呼びかけられなくてもお返事するよ！"
+        "サイコロを振るよ！　ex. 2d6 <= 9"
     }
 
     fn register(&self) -> CreateCommand {
@@ -60,6 +60,10 @@ impl ManamiSlashCommand for SlashCommand {
 
     async fn run(&self, options: &[ResolvedOption<'_>], _: &Bot) -> String {
         run(options)
+    }
+
+    fn is_local_command(&self) -> bool {
+        false
     }
 }
 // slash command

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -24,6 +24,7 @@ pub const PREFIX_DICE_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
 
 pub const SLASH_DICE_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "dice",
+    usage: "/dice <operation>",
     description: "サイコロを振るよ！　ex. 2d6 <= 9",
     register,
     run: |options, _| {

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -11,9 +11,9 @@ use serenity::{
 
 use serenity::{http::Http, model::id::ChannelId, utils::MessageBuilder};
 
-use crate::commands::{StManamiPrefixCommand, StManamiSlashCommand};
+use crate::commands::{ManamiPrefixCommand, ManamiSlashCommand};
 
-pub const PREFIX_DICE_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_DICE_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "dice",
     alias: &[],
     usage: "![n]d<m>",
@@ -23,7 +23,7 @@ pub const PREFIX_DICE_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     is_guild_command: true,
 };
 
-pub const SLASH_DICE_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_DICE_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: "dice",
     usage: "/dice <operation>",
     description: "サイコロを振るよ！　ex. 2d6 <= 9",

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -11,9 +11,60 @@ use serenity::{
 
 use serenity::{http::Http, model::id::ChannelId, utils::MessageBuilder};
 
+use crate::commands::{ManamiPrefixCommand, ManamiSlashCommand};
+use crate::Bot;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    fn usage(&self) -> &'static str {
+        "![n]d<m>"
+    }
+
+    fn description(&self) -> &'static str {
+        "m面ダイスをn回振るよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run_old(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
+pub struct SlashCommand;
+
+const COMMAND_NAME: &str = "dice";
+
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "呼びかけられなくてもお返事するよ！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, options: &[ResolvedOption<'_>], _: &Bot) -> String {
+        run(options)
+    }
+}
 // slash command
 pub fn register() -> CreateCommand {
-    CreateCommand::new("dice")
+    CreateCommand::new(COMMAND_NAME)
         .description("サイコロを振るよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "literal", "ex. 2d6 <= 9")

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -70,6 +70,10 @@ pub fn register() -> CreateCommand {
 }
 
 pub fn run(options: Vec<ResolvedOption>) -> String {
+    run_body(parse_options(options))
+}
+
+fn parse_options(options: Vec<ResolvedOption>) -> Result<Dice, &str> {
     // parse options
     let (literal, num, dice, operator, operand) = options.iter().fold(
         (None, None, None, None, None),
@@ -100,13 +104,20 @@ pub fn run(options: Vec<ResolvedOption>) -> String {
         |s| parse_dice(s).finish().map(|(_, parsed)| parsed),
     );
 
-    let Dice { num, dice, cmp } = match dice {
-        Ok(dice) => dice,
+    match dice {
+        Ok(dice) => Ok(dice),
         Err(Error {
             code: ErrorKind::MapRes,
             ..
-        }) => return "数字がおかしいよ".to_owned(),
-        Err(_) => return "しらないコマンドだよ".to_owned(),
+        }) => Err("数字がおかしいよ"),
+        Err(_) => Err("しらないコマンドだよ"),
+    }
+}
+
+fn run_body(resdice: Result<Dice, &str>) -> String {
+    let (num, dice, cmp) = match resdice {
+        Ok(dice) => (dice.num, dice.dice, dice.cmp),
+        Err(err) => return err.to_owned(),
     };
 
     // roll dice

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -13,7 +13,7 @@ use serenity::{http::Http, model::id::ChannelId, utils::MessageBuilder};
 
 use crate::commands::{StManamiPrefixCommand, StManamiSlashCommand};
 
-pub const DICE_PREFIX_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_DICE_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "",
     usage: "![n]d<m>",
     description: "m面ダイスをn回振るよ！",
@@ -22,7 +22,7 @@ pub const DICE_PREFIX_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     is_guild_command: true,
 };
 
-pub const DICE_SLASH_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_DICE_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "dice",
     description: "サイコロを振るよ！　ex. 2d6 <= 9",
     register,

--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -14,7 +14,8 @@ use serenity::{http::Http, model::id::ChannelId, utils::MessageBuilder};
 use crate::commands::{StManamiPrefixCommand, StManamiSlashCommand};
 
 pub const PREFIX_DICE_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
-    name: "",
+    name: "dice",
+    alias: &[],
     usage: "![n]d<m>",
     description: "m面ダイスをn回振るよ！",
     run: |ctx, _| Box::pin(run_old(ctx)),

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -1,32 +1,17 @@
 use serenity::builder::CreateCommand;
 
-use crate::{commands::ManamiSlashCommand, Bot};
-use serenity::model::application::ResolvedOption;
+use crate::{commands::StManamiSlashCommand, Bot};
 pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "endauto";
 
-impl ManamiSlashCommand for SlashCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
-
-    fn description(&self) -> &'static str {
-        "自動返信を止めるよ！"
-    }
-
-    fn register(&self) -> CreateCommand {
-        register()
-    }
-
-    async fn run(&self, _: &[ResolvedOption<'_>], bot: &Bot) -> String {
-        run(bot).await
-    }
-
-    fn is_local_command(&self) -> bool {
-        true
-    }
-}
+pub const END_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: COMMAND_NAME,
+    description: "自動返信を止めるよ！",
+    register,
+    run: |_, bot| Box::pin(run(bot)),
+    is_local_command: true,
+};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("endauto").description("自動返信を終了するよ")

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -12,7 +12,7 @@ impl ManamiSlashCommand for SlashCommand {
     }
 
     fn description(&self) -> &'static str {
-        "呼びかけられなくてもお返事するよ！"
+        "自動返信を止めるよ！"
     }
 
     fn register(&self) -> CreateCommand {
@@ -21,6 +21,10 @@ impl ManamiSlashCommand for SlashCommand {
 
     async fn run(&self, _: &[ResolvedOption<'_>], bot: &Bot) -> String {
         run(bot).await
+    }
+
+    fn is_local_command(&self) -> bool {
+        true
     }
 }
 

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -1,6 +1,28 @@
 use serenity::builder::CreateCommand;
 
-use crate::Bot;
+use crate::{commands::ManamiSlashCommand, Bot};
+use serenity::model::application::ResolvedOption;
+pub struct SlashCommand;
+
+const COMMAND_NAME: &str = "endauto";
+
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "呼びかけられなくてもお返事するよ！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, _: &[ResolvedOption<'_>], bot: &Bot) -> String {
+        run(bot).await
+    }
+}
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("endauto").description("自動返信を終了するよ")

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -7,6 +7,7 @@ const COMMAND_NAME: &str = "endauto";
 
 pub const SLASH_ENDAUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: COMMAND_NAME,
+    usage: "/endauto",
     description: "自動返信を止めるよ！",
     register,
     run: |_, bot| Box::pin(run(bot)),

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -1,11 +1,11 @@
 use serenity::builder::CreateCommand;
 
-use crate::{commands::StManamiSlashCommand, Bot};
+use crate::{commands::ManamiSlashCommand, Bot};
 pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "endauto";
 
-pub const SLASH_ENDAUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_ENDAUTO_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: COMMAND_NAME,
     usage: "/endauto",
     description: "自動返信を止めるよ！",

--- a/src/commands/endauto.rs
+++ b/src/commands/endauto.rs
@@ -5,7 +5,7 @@ pub struct SlashCommand;
 
 const COMMAND_NAME: &str = "endauto";
 
-pub const END_AUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_ENDAUTO_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: COMMAND_NAME,
     description: "自動返信を止めるよ！",
     register,

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -9,6 +9,7 @@ use crate::{commands::StManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
 pub const SLASH_GEMINI_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "gemini",
+    usage: "/gemini <model>",
     description: "Geminiの設定を変更するよ！",
     register,
     run: |option, bot| {

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -33,25 +33,7 @@ pub fn register() -> CreateCommand {
 }
 
 pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
-    let model = option
-        .iter()
-        .fold(None, |model, option| match (option.name, &option.value) {
-            ("model", ResolvedValue::String(s)) => Some(GeminiModel::from(*s)),
-            _ => model,
-        });
-
-    if let Some(model) = model {
-        let msg = format!("モデルを{}に変更したよ", model);
-        bot.gemini.set_model(model);
-        msg
-    } else {
-        match bot.gemini.generate().await {
-            Ok(content) => content.replace("うだまなみ: ", ""),
-            Err(e) => {
-                format!("Error sending message: {:?}", e)
-            }
-        }
-    }
+    run_body(parse(option, bot), bot).await
 }
 
 fn parse(option: Vec<ResolvedOption<'_>>, _: &Bot) -> Option<GeminiModel> {

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -1,10 +1,33 @@
 use serenity::{
     builder::{CreateCommand, CreateCommandOption},
-    model::application::{CommandOptionType, ResolvedOption, ResolvedValue},
+    model::application::{CommandOptionType, ResolvedValue},
 };
 
-use crate::{ai::GeminiModel, Bot};
+use crate::ai::GeminiModel;
 
+use crate::{commands::ManamiSlashCommand, Bot};
+use serenity::model::application::ResolvedOption;
+pub struct SlashCommand;
+
+const COMMAND_NAME: &str = "endauto";
+
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "呼びかけられなくてもお返事するよ！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, option: &[ResolvedOption<'_>], bot: &Bot) -> String {
+        run(option, bot).await
+    }
+}
 pub fn register() -> CreateCommand {
     CreateCommand::new("gemini")
         .description("Geminiの設定を変更するよ")

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -7,11 +7,14 @@ use crate::ai::GeminiModel;
 
 use crate::{commands::StManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
-pub const GEMINI_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_GEMINI_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "gemini",
     description: "Geminiの設定を変更するよ！",
     register,
-    run: |option, bot| unimplemented!(), /*Box::pin(run(option, bot))*/
+    run: |option, bot| {
+        let opts = parse(option, bot);
+        Box::pin(async move { run_body(opts, bot).await })
+    },
     is_local_command: true,
 };
 
@@ -36,6 +39,30 @@ pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
             _ => model,
         });
 
+    if let Some(model) = model {
+        let msg = format!("モデルを{}に変更したよ", model);
+        bot.gemini.set_model(model);
+        msg
+    } else {
+        match bot.gemini.generate().await {
+            Ok(content) => content.replace("うだまなみ: ", ""),
+            Err(e) => {
+                format!("Error sending message: {:?}", e)
+            }
+        }
+    }
+}
+
+fn parse(option: Vec<ResolvedOption<'_>>, _: &Bot) -> Option<GeminiModel> {
+    option
+        .iter()
+        .fold(None, |model, option| match (option.name, &option.value) {
+            ("model", ResolvedValue::String(s)) => Some(GeminiModel::from(*s)),
+            _ => model,
+        })
+}
+
+async fn run_body(model: Option<GeminiModel>, bot: &Bot) -> String {
     if let Some(model) = model {
         let msg = format!("モデルを{}に変更したよ", model);
         bot.gemini.set_model(model);

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -9,7 +9,7 @@ use crate::{commands::ManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
 pub struct SlashCommand;
 
-const COMMAND_NAME: &str = "endauto";
+const COMMAND_NAME: &str = "gemini";
 
 impl ManamiSlashCommand for SlashCommand {
     fn name(&self) -> &'static [&'static str] {
@@ -17,7 +17,7 @@ impl ManamiSlashCommand for SlashCommand {
     }
 
     fn description(&self) -> &'static str {
-        "呼びかけられなくてもお返事するよ！"
+        "Geminiの設定を変更するよ！"
     }
 
     fn register(&self) -> CreateCommand {
@@ -27,9 +27,13 @@ impl ManamiSlashCommand for SlashCommand {
     async fn run(&self, option: &[ResolvedOption<'_>], bot: &Bot) -> String {
         run(option, bot).await
     }
+
+    fn is_local_command(&self) -> bool {
+        true
+    }
 }
 pub fn register() -> CreateCommand {
-    CreateCommand::new("gemini")
+    CreateCommand::new(COMMAND_NAME)
         .description("Geminiの設定を変更するよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "model", "モデル")

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -5,9 +5,9 @@ use serenity::{
 
 use crate::ai::GeminiModel;
 
-use crate::{commands::StManamiSlashCommand, Bot};
+use crate::{commands::ManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
-pub const SLASH_GEMINI_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_GEMINI_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: "gemini",
     usage: "/gemini <model>",
     description: "Geminiの設定を変更するよ！",

--- a/src/commands/gemini.rs
+++ b/src/commands/gemini.rs
@@ -5,35 +5,18 @@ use serenity::{
 
 use crate::ai::GeminiModel;
 
-use crate::{commands::ManamiSlashCommand, Bot};
+use crate::{commands::StManamiSlashCommand, Bot};
 use serenity::model::application::ResolvedOption;
-pub struct SlashCommand;
+pub const GEMINI_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: "gemini",
+    description: "Geminiの設定を変更するよ！",
+    register,
+    run: |option, bot| unimplemented!(), /*Box::pin(run(option, bot))*/
+    is_local_command: true,
+};
 
-const COMMAND_NAME: &str = "gemini";
-
-impl ManamiSlashCommand for SlashCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
-
-    fn description(&self) -> &'static str {
-        "Geminiの設定を変更するよ！"
-    }
-
-    fn register(&self) -> CreateCommand {
-        register()
-    }
-
-    async fn run(&self, option: &[ResolvedOption<'_>], bot: &Bot) -> String {
-        run(option, bot).await
-    }
-
-    fn is_local_command(&self) -> bool {
-        true
-    }
-}
 pub fn register() -> CreateCommand {
-    CreateCommand::new(COMMAND_NAME)
+    CreateCommand::new("gemini")
         .description("Geminiの設定を変更するよ")
         .add_option(
             CreateCommandOption::new(CommandOptionType::String, "model", "モデル")
@@ -45,7 +28,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
-pub async fn run(option: &[ResolvedOption<'_>], bot: &Bot) -> String {
+pub async fn run(option: Vec<ResolvedOption<'_>>, bot: &Bot) -> String {
     let model = option
         .iter()
         .fold(None, |model, option| match (option.name, &option.value) {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -5,6 +5,7 @@ use super::{StManamiPrefixCommand, StManamiSlashCommand};
 
 pub const PREFIX_HELP_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "help",
+    alias: &[],
     usage: "!help",
     description: "まなみの自己紹介だよ！",
     run: |ctx, _| Box::pin(run_old(ctx)),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -14,6 +14,7 @@ pub const PREFIX_HELP_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
 
 pub const SLASH_HELP_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "help",
+    usage: "/help",
     description: "ヘルプを表示するよ！",
     register,
     run: |_, bot| {
@@ -47,18 +48,13 @@ fn generate_help_rows(usages: &[(&str, &str)], usage_space_minimum: usize) -> St
 const USAGE_SPACE_MINIMUM: usize = 21;
 
 fn generate_slash_help(slash_commands: &[StManamiSlashCommand]) -> String {
-    let usages = &slash_commands
-        .iter()
-        .map(|cmd| (format!("/{}", cmd.name), cmd.description))
-        .collect::<Vec<_>>();
     let help_str = generate_help_rows(
-        &usages
+        &slash_commands
             .iter()
-            .map(|(name, desc)| (name.as_str(), *desc))
+            .map(|cmd| (cmd.usage, cmd.description))
             .collect::<Vec<_>>(),
         USAGE_SPACE_MINIMUM,
     );
-
     let mut content = MessageBuilder::new();
     content.push("## まなみはスラッシュコマンドに対応しているよ！\n");
     content.push("```\n");

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -8,7 +8,7 @@ pub const PREFIX_HELP_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &["たすけて", "助けて"],
     usage: "!help",
     description: "まなみの自己紹介だよ！",
-    run: |ctx, _| Box::pin(run_old(ctx)),
+    run: |ctx| Box::pin(run_old(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,6 +1,4 @@
-use std::result;
-
-use crate::commands::CommandContext;
+use crate::{commands::CommandContext, Bot};
 use serenity::{builder::CreateCommand, utils::MessageBuilder};
 
 use super::{StManamiPrefixCommand, StManamiSlashCommand};
@@ -18,8 +16,8 @@ pub const SLASH_HELP_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "help",
     description: "ヘルプを表示するよ！",
     register,
-    run: |_, _| {
-        let result = run();
+    run: |_, bot| {
+        let result = run(bot);
         Box::pin(async move { result })
     },
     is_local_command: false,
@@ -28,42 +26,8 @@ pub const SLASH_HELP_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
 const ABOUT_ME: &str = "# まなみの自己紹介だよ！\n";
 const ABOUT_GHOSTWRITE: &str = "## 代筆機能があるよ！\nまなみは代筆ができるよ！　DMに送ってもらったメッセージを`!channel`で指定されたチャンネルに転送するよ！\n";
 const ABOUT_AI: &str = "## おはなしもできるよ！\nまなみの部屋でいっぱい話しかけてね！\n";
-const ABOUT_SLASH: &str = "## まなみはスラッシュコマンドに対応しているよ！
-```
-/help                ヘルプを表示するよ！
-/ping                起きてたらお返事するね！
-/dice                サイコロを振るよ！　ex. 2d6 <= 9
-/bf                  まなみはいんたぷりた？　なんだよ！
-```
-";
 
-const ABOUT_DM: &str = "## まなみはDMでコマンドを受け付けるよ！
-```
-!channel             代筆先のチャンネルを指定するよ！
-!erocheck            あなたがエロガキかどうかを判定するよ！
-!help                ヘルプを表示するよ！
-!calc <expr>         数式を計算するよ！
-!var <name>=<expr>   calcで使える変数を定義するよ！
-!varbulk <codeblock> ;区切りで複数の変数を一度に定義するよ！
-!calcsay <expr>      calcの結果を代筆先に送信するよ！
-";
-
-const ABOUT_GUILD: &str = "## まなみはグループチャットでコマンドを受け付けるよ！
-```
-![n]d<m>             m面ダイスをn回振るよ！
-!help                ヘルプを表示するよ！
-!isprime <n>         nが素数かどうかを判定するよ！
-!calc <expr>         数式を計算するよ！
-!var <name>=<expr>   calcで使える変数を定義するよ！
-!varbulk <codeblock> ;区切りで複数の変数を一度に定義するよ！
-!jail <user> [sec]   不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！
-!unjail <user>       収監を解除するよ！
-!cclemon <opponent>  CCレモンをするよ！
-!clear               コマンドを実行したチャンネルのログを忘れるよ！
-```
-";
-
-fn generate_help_str(usages: &[(&str, &str)], usage_space_minimum: usize) -> String {
+fn generate_help_rows(usages: &[(&str, &str)], usage_space_minimum: usize) -> String {
     let usage_space = usages
         .iter()
         .map(|(usage, _)| usage.len() + 1)
@@ -82,12 +46,12 @@ fn generate_help_str(usages: &[(&str, &str)], usage_space_minimum: usize) -> Str
 
 const USAGE_SPACE_MINIMUM: usize = 21;
 
-fn generate_slash_help(slash_commands: &[&StManamiSlashCommand]) -> String {
+fn generate_slash_help(slash_commands: &[StManamiSlashCommand]) -> String {
     let usages = &slash_commands
         .iter()
         .map(|cmd| (format!("/{}", cmd.name), cmd.description))
         .collect::<Vec<_>>();
-    let help_str = generate_help_str(
+    let help_str = generate_help_rows(
         &usages
             .iter()
             .map(|(name, desc)| (name.as_str(), *desc))
@@ -99,12 +63,12 @@ fn generate_slash_help(slash_commands: &[&StManamiSlashCommand]) -> String {
     content.push("## まなみはスラッシュコマンドに対応しているよ！\n");
     content.push("```\n");
     content.push(help_str);
-    content.push("\n```");
+    content.push("\n```\n");
     content.build()
 }
 
-fn generate_dm_help(prefix_commands: &[&StManamiPrefixCommand]) -> String {
-    let help_str = generate_help_str(
+fn generate_dm_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
+    let help_str = generate_help_rows(
         &prefix_commands
             .iter()
             .filter(|cmd| cmd.is_dm_command)
@@ -117,12 +81,12 @@ fn generate_dm_help(prefix_commands: &[&StManamiPrefixCommand]) -> String {
     content.push("## まなみはDMでコマンドを受け付けるよ！\n");
     content.push("```\n");
     content.push(help_str);
-    content.push("\n```");
+    content.push("\n```\n");
     content.build()
 }
 
-fn generate_guild_help(prefix_commands: &[&StManamiPrefixCommand]) -> String {
-    let help_str = generate_help_str(
+fn generate_guild_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
+    let help_str = generate_help_rows(
         &prefix_commands
             .iter()
             .filter(|cmd| !cmd.is_dm_command)
@@ -135,28 +99,52 @@ fn generate_guild_help(prefix_commands: &[&StManamiPrefixCommand]) -> String {
     content.push("## まなみはグループチャットでコマンドを受け付けるよ！\n");
     content.push("```\n");
     content.push(help_str);
-    content.push("\n```");
+    content.push("\n```\n");
     content.build()
+}
+
+fn generate_help(
+    slash_commands: &[StManamiSlashCommand],
+    prefix_commands: &[StManamiPrefixCommand],
+) -> String {
+    let mut content = MessageBuilder::new();
+    content
+        .push(ABOUT_ME)
+        .push(ABOUT_GHOSTWRITE)
+        .push(ABOUT_AI)
+        .push(generate_slash_help(slash_commands))
+        .push(generate_dm_help(prefix_commands))
+        .push(generate_guild_help(prefix_commands))
+        .build()
 }
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("help").description("まなみの自己紹介だよ！")
 }
 
-pub fn run() -> String {
-    let mut content = MessageBuilder::new();
-    content
-        .push(ABOUT_ME)
-        .push(ABOUT_GHOSTWRITE)
-        .push(ABOUT_AI)
-        .push(ABOUT_SLASH)
-        .push(ABOUT_DM)
-        .push(ABOUT_GUILD);
-    content.build()
+pub fn run(bot: &Bot) -> String {
+    generate_help(&bot.slash_commands, &bot.prefix_commands)
 }
 
 pub async fn run_old(ctx: CommandContext<'_>) {
-    let content = run();
+    let content = run(ctx.bot);
 
     ctx.channel_id.say(ctx.cache_http(), content).await.unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{prefix_commands, slash_commands};
+
+    use super::*;
+
+    #[test]
+    fn test_generate_help() {
+        let slash_commands = slash_commands(&[]);
+        let prefix_commands = prefix_commands(&[]);
+
+        let help = generate_help(&slash_commands, &prefix_commands);
+        println!("{}", help);
+        assert!(help.contains("まなみの自己紹介だよ！"));
+    }
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,9 +1,9 @@
 use crate::{commands::CommandContext, Bot};
 use serenity::{builder::CreateCommand, utils::MessageBuilder};
 
-use super::{StManamiPrefixCommand, StManamiSlashCommand};
+use super::{ManamiPrefixCommand, ManamiSlashCommand};
 
-pub const PREFIX_HELP_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_HELP_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "help",
     alias: &[],
     usage: "!help",
@@ -13,7 +13,7 @@ pub const PREFIX_HELP_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     is_guild_command: true,
 };
 
-pub const SLASH_HELP_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_HELP_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: "help",
     usage: "/help",
     description: "ヘルプを表示するよ！",
@@ -48,7 +48,7 @@ fn generate_help_rows(usages: &[(&str, &str)], usage_space_minimum: usize) -> St
 
 const USAGE_SPACE_MINIMUM: usize = 21;
 
-fn generate_slash_help(slash_commands: &[StManamiSlashCommand]) -> String {
+fn generate_slash_help(slash_commands: &[ManamiSlashCommand]) -> String {
     let help_str = generate_help_rows(
         &slash_commands
             .iter()
@@ -64,7 +64,7 @@ fn generate_slash_help(slash_commands: &[StManamiSlashCommand]) -> String {
     content.build()
 }
 
-fn generate_dm_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
+fn generate_dm_help(prefix_commands: &[ManamiPrefixCommand]) -> String {
     let help_str = generate_help_rows(
         &prefix_commands
             .iter()
@@ -82,7 +82,7 @@ fn generate_dm_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
     content.build()
 }
 
-fn generate_guild_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
+fn generate_guild_help(prefix_commands: &[ManamiPrefixCommand]) -> String {
     let help_str = generate_help_rows(
         &prefix_commands
             .iter()
@@ -101,8 +101,8 @@ fn generate_guild_help(prefix_commands: &[StManamiPrefixCommand]) -> String {
 }
 
 fn generate_help(
-    slash_commands: &[StManamiSlashCommand],
-    prefix_commands: &[StManamiPrefixCommand],
+    slash_commands: &[ManamiSlashCommand],
+    prefix_commands: &[ManamiPrefixCommand],
 ) -> String {
     let mut content = MessageBuilder::new();
     content

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -86,7 +86,7 @@ fn generate_guild_help(prefix_commands: &[ManamiPrefixCommand]) -> String {
     let help_str = generate_help_rows(
         &prefix_commands
             .iter()
-            .filter(|cmd| !cmd.is_dm_command)
+            .filter(|cmd| cmd.is_guild_command)
             .map(|cmd| (cmd.usage, cmd.description))
             .collect::<Vec<_>>(),
         USAGE_SPACE_MINIMUM,

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -184,13 +184,14 @@ impl ManamiPrefixCommand for PrefixCommand {
     }
 }
 
+const COMMAND_NAME: &str = "help";
 impl ManamiSlashCommand for SlashCommand {
     fn name(&self) -> &'static [&'static str] {
-        &["help"]
+        &[COMMAND_NAME]
     }
 
     fn description(&self) -> &'static str {
-        "まなみの自己紹介だよ！"
+        "ヘルプを表示するよ！"
     }
 
     fn register(&self) -> serenity::builder::CreateCommand {
@@ -200,10 +201,14 @@ impl ManamiSlashCommand for SlashCommand {
     async fn run(&self, _: &[ResolvedOption<'_>], _: &Bot) -> String {
         self.message.clone()
     }
+
+    fn is_local_command(&self) -> bool {
+        false
+    }
 }
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("help").description("まなみの自己紹介だよ！")
+    CreateCommand::new(COMMAND_NAME).description("まなみの自己紹介だよ！")
 }
 
 pub fn run() -> String {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -5,7 +5,7 @@ use super::{ManamiPrefixCommand, ManamiSlashCommand};
 
 pub const PREFIX_HELP_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "help",
-    alias: &[],
+    alias: &["たすけて", "助けて"],
     usage: "!help",
     description: "まなみの自己紹介だよ！",
     run: |ctx, _| Box::pin(run_old(ctx)),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,7 +1,29 @@
+use std::result;
+
 use crate::commands::CommandContext;
 use serenity::{builder::CreateCommand, utils::MessageBuilder};
 
 use super::{StManamiPrefixCommand, StManamiSlashCommand};
+
+pub const PREFIX_HELP_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "help",
+    usage: "!help",
+    description: "まなみの自己紹介だよ！",
+    run: |ctx, _| Box::pin(run_old(ctx)),
+    is_dm_command: true,
+    is_guild_command: true,
+};
+
+pub const SLASH_HELP_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: "help",
+    description: "ヘルプを表示するよ！",
+    register,
+    run: |_, _| {
+        let result = run();
+        Box::pin(async move { result })
+    },
+    is_local_command: false,
+};
 
 const ABOUT_ME: &str = "# まなみの自己紹介だよ！\n";
 const ABOUT_GHOSTWRITE: &str = "## 代筆機能があるよ！\nまなみは代筆ができるよ！　DMに送ってもらったメッセージを`!channel`で指定されたチャンネルに転送するよ！\n";
@@ -116,23 +138,6 @@ fn generate_guild_help(prefix_commands: &[&StManamiPrefixCommand]) -> String {
     content.push("\n```");
     content.build()
 }
-
-pub const HELP_PREFIX_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
-    name: "help",
-    usage: "!help",
-    description: "まなみの自己紹介だよ！",
-    run: |ctx, _| Box::pin(run_old(ctx)),
-    is_dm_command: true,
-    is_guild_command: true,
-};
-
-pub const HELP_SLASH_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
-    name: "help",
-    description: "ヘルプを表示するよ！",
-    register,
-    run: |_, _| Box::pin(async { run() }),
-    is_local_command: false,
-};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("help").description("まなみの自己紹介だよ！")

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -1,7 +1,7 @@
 use crate::commands::CommandContext;
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_ISPRIME_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_ISPRIME_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "isprime",
     alias: &[],
     usage: "!isprime <n>",

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -1,5 +1,35 @@
 use crate::commands::CommandContext;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["isprime"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!isprime <n>"
+    }
+
+    fn description(&self) -> &'static str {
+        "nが素数かどうかを判定するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
 pub async fn run(ctx: &CommandContext<'_>) {
     let command_args = ctx.args();
 

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -1,7 +1,7 @@
 use crate::commands::CommandContext;
 
 use crate::commands::StManamiPrefixCommand;
-pub const ISPRIME_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_ISPRIME_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "isprime",
     usage: "!isprime <n>",
     description: "nが素数かどうかを判定するよ！",

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -6,7 +6,7 @@ pub const PREFIX_ISPRIME_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!isprime <n>",
     description: "nが素数かどうかを判定するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -1,36 +1,16 @@
 use crate::commands::CommandContext;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
-pub struct PrefixCommand;
+use crate::commands::StManamiPrefixCommand;
+pub const ISPRIME_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "isprime",
+    usage: "!isprime <n>",
+    description: "nが素数かどうかを判定するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: true,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["isprime"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!isprime <n>"
-    }
-
-    fn description(&self) -> &'static str {
-        "nが素数かどうかを判定するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let command_args = ctx.args();
 
     if command_args.len() != 1 {

--- a/src/commands/isprime.rs
+++ b/src/commands/isprime.rs
@@ -3,6 +3,7 @@ use crate::commands::CommandContext;
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_ISPRIME_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "isprime",
+    alias: &[],
     usage: "!isprime <n>",
     description: "nが素数かどうかを判定するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -17,6 +17,7 @@ use tokio::{spawn, time::sleep};
 use crate::commands::StManamiPrefixCommand;
 pub const PREFIX_JAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "jail",
+    alias: &[],
     usage: "!jail <n>",
     description: "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！",
     run: |ctx, _| Box::pin(run_old(ctx)),

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -15,7 +15,7 @@ use serenity::{
 use tokio::{spawn, time::sleep};
 
 use crate::commands::StManamiPrefixCommand;
-pub const JAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_JAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "jail",
     usage: "!jail <n>",
     description: "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！",

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -14,6 +14,35 @@ use serenity::{
 };
 use tokio::{spawn, time::sleep};
 
+use crate::commands::ManamiPrefixCommand;
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["jail"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!jail <n>"
+    }
+
+    fn description(&self) -> &'static str {
+        "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run_old(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        false
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
 const JAIL_TERM_MAX: Duration = Duration::from_secs(3600);
 const JAIL_TERM_DEFAULT: Duration = Duration::from_secs(15);
 

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -14,34 +14,15 @@ use serenity::{
 };
 use tokio::{spawn, time::sleep};
 
-use crate::commands::ManamiPrefixCommand;
-pub struct PrefixCommand;
-
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["jail"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!jail <n>"
-    }
-
-    fn description(&self) -> &'static str {
-        "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run_old(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        false
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
+use crate::commands::StManamiPrefixCommand;
+pub const JAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "jail",
+    usage: "!jail <n>",
+    description: "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！",
+    run: |ctx, _| Box::pin(run_old(ctx)),
+    is_dm_command: false,
+    is_guild_command: true,
+};
 
 const JAIL_TERM_MAX: Duration = Duration::from_secs(3600);
 const JAIL_TERM_DEFAULT: Duration = Duration::from_secs(15);
@@ -61,7 +42,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
-pub async fn run(options: &[ResolvedOption<'_>], ctx: &CommandContext<'_>) -> String {
+pub async fn run(options: Vec<ResolvedOption<'_>>, ctx: &CommandContext<'_>) -> String {
     // 引数からユーザと刑期を取得
     let (user, jailterm) = options.iter().fold(
         (None, JAIL_TERM_DEFAULT),
@@ -140,7 +121,7 @@ pub async fn run(options: &[ResolvedOption<'_>], ctx: &CommandContext<'_>) -> St
     result.unwrap()
 }
 
-pub async fn run_old(ctx: &CommandContext<'_>) {
+pub async fn run_old(ctx: CommandContext<'_>) {
     let reply = ctx.channel_id;
     let args = &ctx.args()[..];
     let bot = ctx.bot;

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -14,8 +14,8 @@ use serenity::{
 };
 use tokio::{spawn, time::sleep};
 
-use crate::commands::StManamiPrefixCommand;
-pub const PREFIX_JAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+use crate::commands::ManamiPrefixCommand;
+pub const PREFIX_JAIL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "jail",
     alias: &[],
     usage: "!jail <n>",

--- a/src/commands/jail.rs
+++ b/src/commands/jail.rs
@@ -20,7 +20,7 @@ pub const PREFIX_JAIL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!jail <n>",
     description: "不届き者を収監して 見せます・袋とじ・管理 以外のカテゴリで喋れなくするよ！",
-    run: |ctx, _| Box::pin(run_old(ctx)),
+    run: |ctx| Box::pin(run_old(ctx)),
     is_dm_command: false,
     is_guild_command: true,
 };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -124,3 +124,24 @@ pub trait ManamiSlashCommand {
         true
     }
 }
+
+pub struct StManamiPrefixCommand {
+    pub name: &'static str,
+    pub usage: &'static str,
+    pub description: &'static str,
+    pub run: fn(
+        &CommandContext<'_>,
+        &[ResolvedOption],
+    ) -> Box<dyn std::future::Future<Output = ()> + Send>,
+    pub is_dm_command: bool,
+    pub is_guild_command: bool,
+}
+
+pub struct StManamiSlashCommand {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub register: fn() -> serenity::builder::CreateCommand,
+    pub run:
+        fn(&[ResolvedOption<'_>], &Bot) -> Box<dyn std::future::Future<Output = String> + Send>,
+    pub is_local_command: bool,
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -105,6 +105,8 @@ pub trait ManamiSlashCommand {
         bot: &Bot,
     ) -> impl std::future::Future<Output = String> + Send;
 
+    fn is_local_command(&self) -> bool;
+
     fn try_register(&self, disabled_commands: &[&str]) -> Option<serenity::builder::CreateCommand> {
         if self.is_enabled(disabled_commands) {
             Some(self.register())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -88,6 +88,7 @@ pub struct StManamiPrefixCommand {
 
 pub struct StManamiSlashCommand {
     pub name: &'static str,
+    pub usage: &'static str,
     pub description: &'static str,
     pub register: fn() -> serenity::builder::CreateCommand,
     pub run: for<'a> fn(Vec<ResolvedOption>, &'a Bot) -> BoxedFuture<'a, String>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -77,7 +77,7 @@ impl<'a> CommandContext<'a> {
 
 type BoxedFuture<'x, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'x>>;
 
-pub struct StManamiPrefixCommand {
+pub struct ManamiPrefixCommand {
     pub name: &'static str,
     pub alias: &'static [&'static str],
     pub usage: &'static str,
@@ -87,7 +87,7 @@ pub struct StManamiPrefixCommand {
     pub is_guild_command: bool,
 }
 
-pub struct StManamiSlashCommand {
+pub struct ManamiSlashCommand {
     pub name: &'static str,
     pub usage: &'static str,
     pub description: &'static str,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,6 @@
+use crate::Bot;
+use serenity::all::ResolvedOption;
+
 pub mod auto;
 pub mod bf;
 pub mod calc;
@@ -67,5 +70,27 @@ impl<'a> CommandContext<'a> {
     #[allow(clippy::missing_const_for_fn)]
     pub fn cache_http(&self) -> &'a serenity::http::Http {
         &self.ctx.http
+    }
+}
+
+pub trait ManamiPrefixCommand {
+    fn name(&self) -> &'static [&'static str];
+    fn description(&self) -> &'static str;
+    fn usage(&self) -> &'static str;
+    async fn run(&self, ctx: &CommandContext<'_>, options: &[ResolvedOption]);
+}
+pub trait ManamiSlashCommand {
+    fn name(&self) -> &'static [&'static str];
+    fn description(&self) -> &'static str;
+    fn register(&self) -> serenity::builder::CreateCommand;
+    async fn run(&self, option: &[ResolvedOption<'_>], bot: &Bot) -> String;
+
+    fn try_register(&self, disabled_commands: &[&str]) -> Option<serenity::builder::CreateCommand> {
+        for name in self.name() {
+            if disabled_commands.contains(name) {
+                return None;
+            }
+        }
+        Some(self.register())
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -79,6 +79,7 @@ type BoxedFuture<'x, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + '
 
 pub struct StManamiPrefixCommand {
     pub name: &'static str,
+    pub alias: &'static [&'static str],
     pub usage: &'static str,
     pub description: &'static str,
     pub run: for<'a> fn(CommandContext<'a>, Vec<ResolvedOption>) -> BoxedFuture<'a, ()>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use crate::Bot;
 use serenity::all::ResolvedOption;
 
@@ -125,23 +127,25 @@ pub trait ManamiSlashCommand {
     }
 }
 
-pub struct StManamiPrefixCommand {
+pub struct StManamiPrefixCommand<'a> {
     pub name: &'static str,
     pub usage: &'static str,
     pub description: &'static str,
     pub run: fn(
-        &CommandContext<'_>,
-        &[ResolvedOption],
-    ) -> Box<dyn std::future::Future<Output = ()> + Send>,
+        CommandContext<'a>,
+        Vec<ResolvedOption>,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>,
     pub is_dm_command: bool,
     pub is_guild_command: bool,
 }
 
-pub struct StManamiSlashCommand {
+pub struct StManamiSlashCommand<'a> {
     pub name: &'static str,
     pub description: &'static str,
     pub register: fn() -> serenity::builder::CreateCommand,
-    pub run:
-        fn(&[ResolvedOption<'_>], &Bot) -> Box<dyn std::future::Future<Output = String> + Send>,
+    pub run: fn(
+        Vec<ResolvedOption>,
+        &'a Bot,
+    ) -> Pin<Box<dyn std::future::Future<Output = String> + Send + 'a>>,
     pub is_local_command: bool,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,7 +82,7 @@ pub struct ManamiPrefixCommand {
     pub alias: &'static [&'static str],
     pub usage: &'static str,
     pub description: &'static str,
-    pub run: for<'a> fn(CommandContext<'a>, Vec<ResolvedOption>) -> BoxedFuture<'a, ()>,
+    pub run: for<'a> fn(CommandContext<'a>) -> BoxedFuture<'a, ()>,
     pub is_dm_command: bool,
     pub is_guild_command: bool,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -92,6 +92,6 @@ pub struct ManamiSlashCommand {
     pub usage: &'static str,
     pub description: &'static str,
     pub register: fn() -> serenity::builder::CreateCommand,
-    pub run: for<'a> fn(Vec<ResolvedOption>, &'a Bot) -> BoxedFuture<'a, String>,
+    pub run: for<'a> fn(Vec<ResolvedOption<'a>>, &'a Bot) -> BoxedFuture<'a, String>,
     pub is_local_command: bool,
 }

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -20,6 +20,10 @@ impl ManamiSlashCommand for SlashCommand {
     async fn run(&self, _: &[ResolvedOption<'_>], _: &crate::Bot) -> String {
         run()
     }
+
+    fn is_local_command(&self) -> bool {
+        false
+    }
 }
 
 // ping command

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -4,6 +4,7 @@ use super::StManamiSlashCommand;
 
 pub const SLASH_PING_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "ping",
+    usage: "/ping",
     description: "起きてたらお返事するね！",
     register,
     run: |_, _| Box::pin(async { run() }),

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,36 +1,19 @@
-use serenity::{all::ResolvedOption, builder::CreateCommand};
+use serenity::builder::CreateCommand;
 
-use super::ManamiSlashCommand;
+use super::StManamiSlashCommand;
 
-pub struct SlashCommand;
-const COMMAND_NAME: &str = "ping";
-impl ManamiSlashCommand for SlashCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &[COMMAND_NAME]
-    }
+pub const PING_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+    name: "ping",
+    description: "起きてたらお返事するね！",
+    register,
+    run: |_, _| Box::pin(async { run() }),
+    is_local_command: false,
+};
 
-    fn description(&self) -> &'static str {
-        "起きてたらお返事するね！"
-    }
-
-    fn register(&self) -> CreateCommand {
-        register()
-    }
-
-    async fn run(&self, _: &[ResolvedOption<'_>], _: &crate::Bot) -> String {
-        run()
-    }
-
-    fn is_local_command(&self) -> bool {
-        false
-    }
-}
-
-// ping command
 pub fn run() -> String {
     "いるよー！".to_owned()
 }
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new(COMMAND_NAME).description("A ping command")
+    CreateCommand::new("ping").description("A ping command")
 }

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,8 +1,8 @@
 use serenity::builder::CreateCommand;
 
-use super::StManamiSlashCommand;
+use super::ManamiSlashCommand;
 
-pub const SLASH_PING_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_PING_COMMAND: ManamiSlashCommand = ManamiSlashCommand {
     name: "ping",
     usage: "/ping",
     description: "起きてたらお返事するね！",

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -2,7 +2,7 @@ use serenity::builder::CreateCommand;
 
 use super::StManamiSlashCommand;
 
-pub const PING_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
+pub const SLASH_PING_COMMAND: StManamiSlashCommand = StManamiSlashCommand {
     name: "ping",
     description: "起きてたらお返事するね！",
     register,

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,4 +1,26 @@
-use serenity::builder::CreateCommand;
+use serenity::{all::ResolvedOption, builder::CreateCommand};
+
+use super::ManamiSlashCommand;
+
+pub struct SlashCommand;
+const COMMAND_NAME: &str = "ping";
+impl ManamiSlashCommand for SlashCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &[COMMAND_NAME]
+    }
+
+    fn description(&self) -> &'static str {
+        "起きてたらお返事するね！"
+    }
+
+    fn register(&self) -> CreateCommand {
+        register()
+    }
+
+    async fn run(&self, _: &[ResolvedOption<'_>], _: &crate::Bot) -> String {
+        run()
+    }
+}
 
 // ping command
 pub fn run() -> String {
@@ -6,5 +28,5 @@ pub fn run() -> String {
 }
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("ping").description("A ping command")
+    CreateCommand::new(COMMAND_NAME).description("A ping command")
 }

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -4,10 +4,41 @@ use std::{sync::Arc, time::Instant};
 use dashmap::DashMap;
 
 use serenity::{
+    all::ResolvedOption,
     model::id::{ChannelId, GuildId, RoleId, UserId},
     prelude::*,
     utils::parse_user_mention,
 };
+
+use super::ManamiPrefixCommand;
+
+pub struct PrefixCommand;
+
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["unjail"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!unjail <user>"
+    }
+
+    fn description(&self) -> &'static str {
+        "収監を解除するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        false
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
 
 pub async fn run(ctx: &CommandContext<'_>) {
     let reply = ctx.channel_id;

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -13,6 +13,7 @@ use super::StManamiPrefixCommand;
 
 pub const PREFIX_UNJAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "unjail",
+    alias: &[],
     usage: "!unjail <user>",
     description: "収監を解除するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -4,43 +4,23 @@ use std::{sync::Arc, time::Instant};
 use dashmap::DashMap;
 
 use serenity::{
-    all::ResolvedOption,
     model::id::{ChannelId, GuildId, RoleId, UserId},
     prelude::*,
     utils::parse_user_mention,
 };
 
-use super::ManamiPrefixCommand;
+use super::StManamiPrefixCommand;
 
-pub struct PrefixCommand;
+pub const UNJAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "unjail",
+    usage: "!unjail <user>",
+    description: "収監を解除するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: false,
+    is_guild_command: true,
+};
 
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["unjail"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!unjail <user>"
-    }
-
-    fn description(&self) -> &'static str {
-        "収監を解除するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        false
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let reply = ctx.channel_id;
     let args = &ctx.args()[..];
     let bot = ctx.bot;

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -16,7 +16,7 @@ pub const PREFIX_UNJAIL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!unjail <user>",
     description: "収監を解除するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: false,
     is_guild_command: true,
 };

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -11,7 +11,7 @@ use serenity::{
 
 use super::StManamiPrefixCommand;
 
-pub const UNJAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_UNJAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "unjail",
     usage: "!unjail <user>",
     description: "収監を解除するよ！",

--- a/src/commands/unjail.rs
+++ b/src/commands/unjail.rs
@@ -9,9 +9,9 @@ use serenity::{
     utils::parse_user_mention,
 };
 
-use super::StManamiPrefixCommand;
+use super::ManamiPrefixCommand;
 
-pub const PREFIX_UNJAIL_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_UNJAIL_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "unjail",
     alias: &[],
     usage: "!unjail <user>",

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -1,52 +1,24 @@
 use crate::Bot;
-use serenity::all::ResolvedOption;
 use serenity::http::Http;
 use serenity::model::id::ChannelId;
 
 use crate::calculator::{self, val_as_str};
 use crate::commands::CommandContext;
 
-use super::ManamiPrefixCommand;
+use super::StManamiPrefixCommand;
 
-pub struct PrefixCommand;
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["var"]
-    }
-
-    fn usage(&self) -> &'static str {
-        "!var <name>=<expr>"
-    }
-
-    fn description(&self) -> &'static str {
-        "calcで使える変数を定義するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-
-    fn is_enabled(&self, disabled_commands: &[&str]) -> bool {
-        for name in self.name() {
-            if disabled_commands.contains(name) {
-                return false;
-            }
-        }
-        true
-    }
-}
+pub const VAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "var",
+    usage: "!var <name>=<expr>",
+    description: "calcで使える変数を定義するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: true,
+};
 
 const VAR_DEFAULT: &str = "_";
 
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let reply = ctx.channel_id;
     let bot = ctx.bot;
     let input = ctx.args().join(" ");

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -1,9 +1,48 @@
 use crate::Bot;
+use serenity::all::ResolvedOption;
 use serenity::http::Http;
 use serenity::model::id::ChannelId;
 
 use crate::calculator::{self, val_as_str};
 use crate::commands::CommandContext;
+
+use super::ManamiPrefixCommand;
+
+pub struct PrefixCommand;
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["var"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!var <name>=<expr>"
+    }
+
+    fn description(&self) -> &'static str {
+        "calcで使える変数を定義するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+
+    fn is_enabled(&self, disabled_commands: &[&str]) -> bool {
+        for name in self.name() {
+            if disabled_commands.contains(name) {
+                return false;
+            }
+        }
+        true
+    }
+}
 
 const VAR_DEFAULT: &str = "_";
 

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -7,7 +7,7 @@ use crate::commands::CommandContext;
 
 use super::StManamiPrefixCommand;
 
-pub const VAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_VAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "var",
     usage: "!var <name>=<expr>",
     description: "calcで使える変数を定義するよ！",

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -12,7 +12,7 @@ pub const PREFIX_VAR_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!var <name>=<expr>",
     description: "calcで使える変数を定義するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -9,6 +9,7 @@ use super::StManamiPrefixCommand;
 
 pub const PREFIX_VAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "var",
+    alias: &[],
     usage: "!var <name>=<expr>",
     description: "calcで使える変数を定義するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/var.rs
+++ b/src/commands/var.rs
@@ -5,9 +5,9 @@ use serenity::model::id::ChannelId;
 use crate::calculator::{self, val_as_str};
 use crate::commands::CommandContext;
 
-use super::StManamiPrefixCommand;
+use super::ManamiPrefixCommand;
 
-pub const PREFIX_VAR_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_VAR_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "var",
     alias: &[],
     usage: "!var <name>=<expr>",

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -6,6 +6,7 @@ use crate::commands::StManamiPrefixCommand;
 
 pub const PREFIX_VARBULK_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "varbulk",
+    alias: &[],
     usage: "!varbulk <codeblock>",
     description: ";区切りで複数の変数を一度に定義するよ！",
     run: |ctx, _| Box::pin(run(ctx)),

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -2,9 +2,9 @@ use crate::commands::var;
 use crate::commands::CommandContext;
 use regex::Regex;
 
-use crate::commands::StManamiPrefixCommand;
+use crate::commands::ManamiPrefixCommand;
 
-pub const PREFIX_VARBULK_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_VARBULK_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     name: "varbulk",
     alias: &[],
     usage: "!varbulk <codeblock>",

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -9,7 +9,7 @@ pub const PREFIX_VARBULK_COMMAND: ManamiPrefixCommand = ManamiPrefixCommand {
     alias: &[],
     usage: "!varbulk <codeblock>",
     description: ";区切りで複数の変数を一度に定義するよ！",
-    run: |ctx, _| Box::pin(run(ctx)),
+    run: |ctx| Box::pin(run(ctx)),
     is_dm_command: true,
     is_guild_command: true,
 };

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -2,37 +2,18 @@ use crate::commands::var;
 use crate::commands::CommandContext;
 use regex::Regex;
 
-use crate::commands::ManamiPrefixCommand;
-use serenity::all::ResolvedOption;
+use crate::commands::StManamiPrefixCommand;
 
-pub struct PrefixCommand;
-impl ManamiPrefixCommand for PrefixCommand {
-    fn name(&self) -> &'static [&'static str] {
-        &["varbulk"]
-    }
+pub const VARBULK_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+    name: "varbulk",
+    usage: "!varbulk <codeblock>",
+    description: ";区切りで複数の変数を一度に定義するよ！",
+    run: |ctx, _| Box::pin(run(ctx)),
+    is_dm_command: true,
+    is_guild_command: true,
+};
 
-    fn usage(&self) -> &'static str {
-        "!varbulk <codeblock>"
-    }
-
-    fn description(&self) -> &'static str {
-        ";区切りで複数の変数を一度に定義するよ！"
-    }
-
-    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
-        run(ctx).await
-    }
-
-    fn is_dm_command(&self) -> bool {
-        true
-    }
-
-    fn is_guild_command(&self) -> bool {
-        true
-    }
-}
-
-pub async fn run(ctx: &CommandContext<'_>) {
+pub async fn run(ctx: CommandContext<'_>) {
     let input = ctx.args().join(" ");
 
     let code_pattern = Regex::new(r"```[a-zA-Z0-9]*(.*)```").unwrap();
@@ -44,13 +25,12 @@ pub async fn run(ctx: &CommandContext<'_>) {
     };
     let split: Vec<&str> = input.split(';').collect();
 
-    let mut ctx2 = ctx.clone();
-
     for s in split {
         if s.trim().is_empty() {
             continue;
         }
+        let mut ctx2 = ctx.clone();
         ctx2.command = s.to_owned();
-        var::run(&ctx2).await;
+        var::run(ctx2).await;
     }
 }

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -2,6 +2,36 @@ use crate::commands::var;
 use crate::commands::CommandContext;
 use regex::Regex;
 
+use crate::commands::ManamiPrefixCommand;
+use serenity::all::ResolvedOption;
+
+pub struct PrefixCommand;
+impl ManamiPrefixCommand for PrefixCommand {
+    fn name(&self) -> &'static [&'static str] {
+        &["varbulk"]
+    }
+
+    fn usage(&self) -> &'static str {
+        "!varbulk <codeblock>"
+    }
+
+    fn description(&self) -> &'static str {
+        ";区切りで複数の変数を一度に定義するよ！"
+    }
+
+    async fn run(&self, ctx: &CommandContext<'_>, _: &[ResolvedOption<'_>]) {
+        run(ctx).await
+    }
+
+    fn is_dm_command(&self) -> bool {
+        true
+    }
+
+    fn is_guild_command(&self) -> bool {
+        true
+    }
+}
+
 pub async fn run(ctx: &CommandContext<'_>) {
     let input = ctx.args().join(" ");
 

--- a/src/commands/varbulk.rs
+++ b/src/commands/varbulk.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 
 use crate::commands::StManamiPrefixCommand;
 
-pub const VARBULK_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
+pub const PREFIX_VARBULK_COMMAND: StManamiPrefixCommand = StManamiPrefixCommand {
     name: "varbulk",
     usage: "!varbulk <codeblock>",
     description: ";区切りで複数の変数を一度に定義するよ！",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,12 +129,12 @@ impl Bot {
 
 pub fn slash_commands(disabled_commands: &[&str]) -> Vec<StManamiSlashCommand> {
     [
-        commands::auto::SLASH_AUTO_COMMAND,
-        commands::bf::SLASH_BF_COMMAND,
-        commands::endauto::SLASH_ENDAUTO_COMMAND,
-        commands::gemini::SLASH_GEMINI_COMMAND,
         commands::help::SLASH_HELP_COMMAND,
         commands::ping::SLASH_PING_COMMAND,
+        commands::bf::SLASH_BF_COMMAND,
+        commands::auto::SLASH_AUTO_COMMAND,
+        commands::endauto::SLASH_ENDAUTO_COMMAND,
+        commands::gemini::SLASH_GEMINI_COMMAND,
     ]
     .into_iter()
     .filter(|command| !disabled_commands.contains(&command.name))
@@ -143,16 +143,16 @@ pub fn slash_commands(disabled_commands: &[&str]) -> Vec<StManamiSlashCommand> {
 
 pub fn prefix_commands(disabled_commands: &[&str]) -> Vec<StManamiPrefixCommand> {
     [
-        commands::calc::PREFIX_CALC_COMMAND,
-        commands::calcsay::PREFIX_CALCSAY_COMMAND,
-        commands::cclemon::PREFIX_CCLEMON_COMMAND,
+        commands::help::PREFIX_HELP_COMMAND,
+        commands::dice::PREFIX_DICE_COMMAND,
+        commands::isprime::PREFIX_ISPRIME_COMMAND,
         commands::channel::PREFIX_CHANNEL_COMMAND,
         commands::clear::PREFIX_CLEAR_COMMAND,
-        commands::dice::PREFIX_DICE_COMMAND,
-        commands::help::PREFIX_HELP_COMMAND,
-        commands::isprime::PREFIX_ISPRIME_COMMAND,
         commands::jail::PREFIX_JAIL_COMMAND,
         commands::unjail::PREFIX_UNJAIL_COMMAND,
+        commands::cclemon::PREFIX_CCLEMON_COMMAND,
+        commands::calc::PREFIX_CALC_COMMAND,
+        commands::calcsay::PREFIX_CALCSAY_COMMAND,
         commands::var::PREFIX_VAR_COMMAND,
         commands::varbulk::PREFIX_VARBULK_COMMAND,
     ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,6 @@ pub struct Bot {
     pub jail_process: Arc<DashMap<UserId, (usize, Instant)>>,
     pub jail_id: Arc<Mutex<usize>>,
 
-    pub disabled_commands: Vec<String>,
-
     pub channel_ids: Vec<ChannelId>,
     pub guild_id: GuildId,
     pub erogaki_role_id: RoleId,
@@ -98,15 +96,12 @@ pub struct Bot {
     pub reply_to_all_mode: Arc<Mutex<ReplyToAllModeData>>,
 
     pub gemini: ai::GeminiAI,
+
+    pub slash_commands: Vec<StManamiSlashCommand>,
+    pub prefix_commands: Vec<StManamiPrefixCommand>,
 }
 
 impl Bot {
-    pub fn is_disabled_command(&self, command: &str) -> bool {
-        self.disabled_commands
-            .iter()
-            .any(|disabled| disabled == command)
-    }
-
     pub fn get_user_room_pointer(&self, user_id: &UserId) -> ChannelId {
         self.userdata
             .entry(*user_id)
@@ -130,6 +125,40 @@ impl Bot {
             .room_pointer = room_pointer;
         Ok(())
     }
+}
+
+pub fn slash_commands(disabled_commands: &[&str]) -> Vec<StManamiSlashCommand> {
+    [
+        commands::auto::SLASH_AUTO_COMMAND,
+        commands::bf::SLASH_BF_COMMAND,
+        commands::endauto::SLASH_ENDAUTO_COMMAND,
+        commands::gemini::SLASH_GEMINI_COMMAND,
+        commands::help::SLASH_HELP_COMMAND,
+        commands::ping::SLASH_PING_COMMAND,
+    ]
+    .into_iter()
+    .filter(|command| !disabled_commands.contains(&command.name))
+    .collect::<Vec<_>>()
+}
+
+pub fn prefix_commands(disabled_commands: &[&str]) -> Vec<StManamiPrefixCommand> {
+    [
+        commands::calc::PREFIX_CALC_COMMAND,
+        commands::calcsay::PREFIX_CALCSAY_COMMAND,
+        commands::cclemon::PREFIX_CCLEMON_COMMAND,
+        commands::channel::PREFIX_CHANNEL_COMMAND,
+        commands::clear::PREFIX_CLEAR_COMMAND,
+        commands::dice::PREFIX_DICE_COMMAND,
+        commands::help::PREFIX_HELP_COMMAND,
+        commands::isprime::PREFIX_ISPRIME_COMMAND,
+        commands::jail::PREFIX_JAIL_COMMAND,
+        commands::unjail::PREFIX_UNJAIL_COMMAND,
+        commands::var::PREFIX_VAR_COMMAND,
+        commands::varbulk::PREFIX_VARBULK_COMMAND,
+    ]
+    .into_iter()
+    .filter(|command| !disabled_commands.contains(&command.name))
+    .collect::<Vec<_>>()
 }
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ async fn direct_message(bot: &Bot, ctx: &Context, msg: &Message) {
         .prefix_commands
         .iter()
         .filter(|cmd| cmd.is_dm_command)
-        .find(|cmd| cmd.alias.contains(&command_name))
+        .find(|cmd| cmd.name == command_name || cmd.alias.contains(&command_name))
     {
         Some(cmd) => (cmd.run)(command_context).await,
         None => {
@@ -356,7 +356,7 @@ async fn guild_message(bot: &Bot, ctx: &Context, msg: &Message) {
         .prefix_commands
         .iter()
         .filter(|cmd| cmd.is_guild_command)
-        .find(|cmd| cmd.alias.contains(&command_name))
+        .find(|cmd| cmd.name == command_name || cmd.alias.contains(&command_name))
     {
         Some(cmd) => (cmd.run)(command_context).await,
         None => {
@@ -365,7 +365,7 @@ async fn guild_message(bot: &Bot, ctx: &Context, msg: &Message) {
                     .prefix_commands
                     .iter()
                     .filter(|cmd| cmd.is_guild_command)
-                    .find(|cmd| cmd.alias.contains(&"dice"))
+                    .find(|cmd| cmd.name == "dice")
                 {
                     return (cmd.run)(command_context).await;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ impl EventHandler for Bot {
                 &command.data.name,
             );
             let content = match command.data.name.as_str() {
-                "help" => Some(help::run()),
+                "help" => Some(help::run(self)),
                 "ping" => Some(ping::run()),
                 "bf" => Some(bf::run(command.data.options())),
                 "dice" => Some(dice::run(command.data.options())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,22 +194,21 @@ impl EventHandler for Bot {
             .guild_id
             .set_commands(
                 &ctx.http,
-                vec![gemini::register(), auto::register(), endauto::register()]
-                    .into_iter()
-                    //.filter(|command| !self.is_disabled_command(&command.name))
+                self.slash_commands
+                    .iter()
+                    .filter(|cmd| cmd.is_local_command)
+                    .map(|cmd| (cmd.register)())
                     .collect::<Vec<_>>(),
             )
             .await;
 
         // グローバルコマンドの登録
-        let global_commands = [
-            help::register(),
-            ping::register(),
-            bf::register(),
-            dice::register(),
-        ];
-        for command in global_commands.into_iter() {
-            let _ = Command::create_global_command(&ctx.http, command).await;
+        for command in self
+            .slash_commands
+            .iter()
+            .filter(|cmd| !cmd.is_local_command)
+        {
+            let _ = Command::create_global_command(&ctx.http, (command.register)()).await;
         }
 
         // roles のいずれかが付いているユーザーを恩赦

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl EventHandler for Bot {
                     author_id: &member.user.id,
                     command: "".to_owned(),
                 };
-                unjail::run(&command_context).await;
+                unjail::run(command_context).await;
             }
         }
     }
@@ -214,10 +214,10 @@ impl EventHandler for Bot {
             let content = match command.data.name.as_str() {
                 "help" => Some(help::run()),
                 "ping" => Some(ping::run()),
-                "bf" => Some(bf::run(&command.data.options())),
-                "dice" => Some(dice::run(&command.data.options())),
-                "gemini" => Some(gemini::run(&command.data.options(), self).await),
-                "auto" => Some(auto::run(&command.data.options(), self).await),
+                "bf" => Some(bf::run(command.data.options())),
+                "dice" => Some(dice::run(command.data.options())),
+                "gemini" => Some(gemini::run(command.data.options(), self).await),
+                "auto" => Some(auto::run(command.data.options(), self).await),
                 "endauto" => Some(endauto::run(self).await),
                 _ => Some("知らないコマンドだよ！".to_owned()),
             };
@@ -260,12 +260,12 @@ async fn direct_message(bot: &Bot, ctx: &Context, msg: &Message) {
     let command_name = &command_context.command_name()[..];
 
     match command_name {
-        "channel" => channel::run(&command_context).await,
-        "help" | "たすけて" | "助けて" => help::run_old(&command_context).await,
-        "calc" => calc::run(&command_context).await,
-        "var" => var::run(&command_context).await,
-        "varbulk" => varbulk::run(&command_context).await,
-        "calcsay" => calcsay::run(&command_context).await,
+        "channel" => channel::run(command_context).await,
+        "help" | "たすけて" | "助けて" => help::run_old(command_context).await,
+        "calc" => calc::run(command_context).await,
+        "var" => var::run(command_context).await,
+        "varbulk" => varbulk::run(command_context).await,
+        "calcsay" => calcsay::run(command_context).await,
 
         // Unknown command
         _ => {
@@ -329,20 +329,20 @@ async fn guild_message(bot: &Bot, ctx: &Context, msg: &Message) {
 
     match command_name {
         "help" | "たすけて" | "助けて" => {
-            help::run_old(&command_context).await;
+            help::run_old(command_context).await;
         }
-        "isprime" => isprime::run(&command_context).await,
-        "calc" => calc::run(&command_context).await,
-        "var" => var::run(&command_context).await,
-        "varbulk" => varbulk::run(&command_context).await,
-        "cclemon" => commands::cclemon::run(&command_context).await,
-        "jail" => jail::run_old(&command_context).await,
-        "unjail" => unjail::run(&command_context).await,
-        "clear" | "全部忘れて" => clear::run(&command_context).await,
+        "isprime" => isprime::run(command_context).await,
+        "calc" => calc::run(command_context).await,
+        "var" => var::run(command_context).await,
+        "varbulk" => varbulk::run(command_context).await,
+        "cclemon" => commands::cclemon::run(command_context).await,
+        "jail" => jail::run_old(command_context).await,
+        "unjail" => unjail::run(command_context).await,
+        "clear" | "全部忘れて" => clear::run(command_context).await,
         // Unknown command
         _ => {
             if msg.content.starts_with("!") {
-                dice::run_old(&command_context).await
+                dice::run_old(command_context).await
             } else if msg.channel_id.get() == bot.channel_ids[4].get() {
                 // まなみが自由に応答するコーナー
                 let content = if response_to_all {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl EventHandler for Bot {
             .await;
 
         // グローバルコマンドの登録
-        let global_commands =[
+        let global_commands = [
             help::register(),
             ping::register(),
             bf::register(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,22 +239,19 @@ impl EventHandler for Bot {
                 &command,
                 &command.data.name,
             );
-            let content = match command.data.name.as_str() {
-                "help" => Some(help::run(self)),
-                "ping" => Some(ping::run()),
-                "bf" => Some(bf::run(command.data.options())),
-                "dice" => Some(dice::run(command.data.options())),
-                "gemini" => Some(gemini::run(command.data.options(), self).await),
-                "auto" => Some(auto::run(command.data.options(), self).await),
-                "endauto" => Some(endauto::run(self).await),
-                _ => Some("知らないコマンドだよ！".to_owned()),
+            let content = match self
+                .slash_commands
+                .iter()
+                .find(|cmd| cmd.name == command.data.name)
+            {
+                Some(cmd) => (cmd.run)(command.data.options(), self).await,
+                None => "知らないコマンドだよ！".to_owned(),
             };
-            if let Some(content) = content {
-                let data = CreateInteractionResponseMessage::new().content(content);
-                let builder = CreateInteractionResponse::Message(data);
-                if let Err(why) = command.create_response(&ctx.http, builder).await {
-                    error!("Error sending message: {:?}", why);
-                }
+
+            let data = CreateInteractionResponseMessage::new().content(content);
+            let builder = CreateInteractionResponse::Message(data);
+            if let Err(why) = command.create_response(&ctx.http, builder).await {
+                error!("Error sending message: {:?}", why);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ pub struct Bot {
 
     pub gemini: ai::GeminiAI,
 
-    pub slash_commands: Vec<StManamiSlashCommand>,
-    pub prefix_commands: Vec<StManamiPrefixCommand>,
+    pub slash_commands: Vec<ManamiSlashCommand>,
+    pub prefix_commands: Vec<ManamiPrefixCommand>,
 }
 
 impl Bot {
@@ -127,7 +127,7 @@ impl Bot {
     }
 }
 
-pub fn slash_commands(disabled_commands: &[&str]) -> Vec<StManamiSlashCommand> {
+pub fn slash_commands(disabled_commands: &[&str]) -> Vec<ManamiSlashCommand> {
     [
         commands::help::SLASH_HELP_COMMAND,
         commands::ping::SLASH_PING_COMMAND,
@@ -141,7 +141,7 @@ pub fn slash_commands(disabled_commands: &[&str]) -> Vec<StManamiSlashCommand> {
     .collect::<Vec<_>>()
 }
 
-pub fn prefix_commands(disabled_commands: &[&str]) -> Vec<StManamiPrefixCommand> {
+pub fn prefix_commands(disabled_commands: &[&str]) -> Vec<ManamiPrefixCommand> {
     [
         commands::help::PREFIX_HELP_COMMAND,
         commands::dice::PREFIX_DICE_COMMAND,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,52 @@ pub struct Bot {
 }
 
 impl Bot {
+    pub fn new(
+        channel_ids: Vec<ChannelId>,
+        debug_channel_id: ChannelId,
+
+        guild_id: GuildId,
+        erogaki_role_id: RoleId,
+        jail_mark_role_id: RoleId,
+        jail_main_role_id: RoleId,
+
+        gemini: ai::GeminiAI,
+
+        commit_hash: Option<String>,
+        commit_date: Option<String>,
+
+        disabled_commands: &[&str]
+    ) -> Self {
+
+        let userdata = DashMap::new();
+        let variables = DashMap::new();
+        let jail_process = Arc::new(DashMap::new());
+        let jail_id = Arc::new(Mutex::new(0));
+        let reply_to_all_mode = Arc::new(Mutex::new(ReplyToAllModeData::blank()));
+        let prefix_commands = prefix_commands(&disabled_commands);
+        let slash_commands = slash_commands(&disabled_commands);
+
+        Self {
+            userdata,
+            jail_process,
+            jail_id,
+            channel_ids,
+            debug_channel_id,
+            guild_id,
+            erogaki_role_id,
+            jail_mark_role_id,
+            jail_main_role_id,
+            commit_hash,
+            commit_date,
+            variables,
+            reply_to_all_mode,
+            gemini,
+            prefix_commands,
+            slash_commands,
+        }
+    }
+
+
     pub fn get_user_room_pointer(&self, user_id: &UserId) -> ChannelId {
         self.userdata
             .entry(*user_id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl ReplyToAllModeData {
         self.until = Some(Instant::now() + self.duration);
     }
 
-    pub fn end(&mut self) {
+    const fn end(&mut self) {
         self.until = None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ async fn serenity(
         |rooms| {
             rooms
                 .split(',')
-                .map(|id| ChannelId::from_str(id).unwrap())
+                .map(|id| ChannelId::from_str(id.trim()).unwrap())
                 .collect()
         },
     );
@@ -63,7 +63,7 @@ async fn serenity(
         .map(|commands| {
             commands
                 .split(',')
-                .map(|command| command.to_owned())
+                .map(|command| command.trim().to_owned())
                 .collect::<Vec<String>>()
         })
         .unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,11 @@ async fn serenity(
         },
     );
 
+    let debug_channel_id = secrets
+        .get("DEBUG_ROOM_ID")
+        .map(|id| ChannelId::from_str(&id).unwrap())
+        .unwrap_or_default();
+
     let disabled_commands = secrets
         .get("DISABLED_COMMANDS")
         .map(|commands| {
@@ -111,6 +116,7 @@ async fn serenity(
             jail_process,
             jail_id,
             channel_ids,
+            debug_channel_id,
             guild_id,
             erogaki_role_id,
             jail_mark_role_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,16 @@ async fn serenity(
             }
         };
 
+    let disabled_commands = secrets
+        .get("DISABLED_COMMANDS")
+        .map(|commands| {
+            commands
+                .split(',')
+                .map(|command| command.to_string())
+                .collect::<Vec<String>>()
+        })
+        .unwrap_or_default();
+
     // 取得できなければ KOCHIKITE_GUILD_ID を使う
     let guild_id = secrets
         .get("DISCORD_GUILD_ID")
@@ -91,6 +101,7 @@ async fn serenity(
             userdata,
             jail_process,
             jail_id,
+            disabled_commands,
             channel_ids,
             guild_id,
             erogaki_role_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use shuttle_runtime::SecretStore;
 
 use udamanami::ai;
 use udamanami::Bot;
+use udamanami::{prefix_commands, slash_commands};
 
 #[shuttle_runtime::main]
 async fn serenity(
@@ -61,6 +62,10 @@ async fn serenity(
                 .collect::<Vec<String>>()
         })
         .unwrap_or_default();
+    let disabled_commands = disabled_commands
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>();
 
     // 取得できなければ KOCHIKITE_GUILD_ID を使う
     let guild_id = secrets
@@ -97,12 +102,14 @@ async fn serenity(
 
     let reply_to_all_mode = Arc::new(Mutex::new(udamanami::ReplyToAllModeData::blank()));
 
+    let prefix_commands = prefix_commands(&disabled_commands);
+    let slash_commands = slash_commands(&disabled_commands);
+
     let client = Client::builder(&token, intents)
         .event_handler(Bot {
             userdata,
             jail_process,
             jail_id,
-            disabled_commands,
             channel_ids,
             guild_id,
             erogaki_role_id,
@@ -112,8 +119,9 @@ async fn serenity(
             commit_date,
             variables,
             reply_to_all_mode,
-
             gemini,
+            prefix_commands,
+            slash_commands,
         })
         .await
         .expect("Err creating client");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,32 +31,33 @@ async fn serenity(
         | GatewayIntents::DIRECT_MESSAGES;
 
     let userdata = DashMap::new();
-    let channel_ids = 
-        match secrets.get("ROOMS_ID") {
-            Some(rooms) => rooms
+    let channel_ids = secrets.get("ROOMS_ID").map_or_else(
+        || {
+            vec![
+                secrets.get("FREETALK1_ROOM_ID"),
+                secrets.get("FREETALK2_ROOM_ID"),
+                secrets.get("MADSISTERS_ROOM_ID"),
+                secrets.get("SHYBOYS_ROOM_ID"),
+                secrets.get("DEBUG_ROOM_ID"),
+            ]
+            .into_iter()
+            .map(|id| ChannelId::from_str(&id.unwrap()).unwrap())
+            .collect()
+        },
+        |rooms| {
+            rooms
                 .split(',')
                 .map(|id| ChannelId::from_str(id).unwrap())
-                .collect(),
-            None => {
-                vec![
-                    secrets.get("FREETALK1_ROOM_ID"),
-                    secrets.get("FREETALK2_ROOM_ID"),
-                    secrets.get("MADSISTERS_ROOM_ID"),
-                    secrets.get("SHYBOYS_ROOM_ID"),
-                    secrets.get("DEBUG_ROOM_ID"),
-                ]
-                .into_iter()
-                .map(|id| ChannelId::from_str(&id.unwrap()).unwrap())
                 .collect()
-            }
-        };
+        },
+    );
 
     let disabled_commands = secrets
         .get("DISABLED_COMMANDS")
         .map(|commands| {
             commands
                 .split(',')
-                .map(|command| command.to_string())
+                .map(|command| command.to_owned())
                 .collect::<Vec<String>>()
         })
         .unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,16 +31,25 @@ async fn serenity(
         | GatewayIntents::DIRECT_MESSAGES;
 
     let userdata = DashMap::new();
-    let channel_ids = vec![
-        secrets.get("FREETALK1_ROOM_ID"),
-        secrets.get("FREETALK2_ROOM_ID"),
-        secrets.get("MADSISTERS_ROOM_ID"),
-        secrets.get("SHYBOYS_ROOM_ID"),
-        secrets.get("DEBUG_ROOM_ID"),
-    ]
-    .into_iter()
-    .map(|id| ChannelId::from_str(&id.unwrap()).unwrap())
-    .collect();
+    let channel_ids = 
+        match secrets.get("ROOMS_ID") {
+            Some(rooms) => rooms
+                .split(',')
+                .map(|id| ChannelId::from_str(id).unwrap())
+                .collect(),
+            None => {
+                vec![
+                    secrets.get("FREETALK1_ROOM_ID"),
+                    secrets.get("FREETALK2_ROOM_ID"),
+                    secrets.get("MADSISTERS_ROOM_ID"),
+                    secrets.get("SHYBOYS_ROOM_ID"),
+                    secrets.get("DEBUG_ROOM_ID"),
+                ]
+                .into_iter()
+                .map(|id| ChannelId::from_str(&id.unwrap()).unwrap())
+                .collect()
+            }
+        };
 
     // 取得できなければ KOCHIKITE_GUILD_ID を使う
     let guild_id = secrets


### PR DESCRIPTION
- 既存のコマンドを ManamiPrefixCommand と ManamiSlashCommand にまとめた
- メッセージから抜き出されたコマンドを実行する部分を簡略化した
- !helpのメッセージがコマンド一覧に基づいて生成されるようになった
- コマンド無効化用の環境変数を導入した
- 代筆チャンネルを指定できるようにした