### PR TITLE
デプロイ先の移住 / Docker化

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.git/
+.github/
+*.md
+.dockerignore
+Dockerfile
+railway.toml
+deploy.sh
+generate_entity.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set commit metadata
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Shuttle Deploy
+name: Railway Deploy
 
 on:
   push:
@@ -11,33 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set commit metadata
         run: |
           echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "COMMIT_DATE=$(git show -s --format=%ci HEAD)" >> $GITHUB_ENV
 
-      - uses: shuttle-hq/deploy-action@v2
-        with:
-          shuttle-api-key: ${{ secrets.SHUTTLE_API_KEY }}
-          project-id: ${{ secrets.SHUTTLE_PROJECT_ID || 'proj_01JCJS9WKRQ1RC9MVZW6WDJK97' }}
-          extra-args: --allow-dirty
-          secrets: |
-            AI_API_KEY = '${{ secrets.AI_API_KEY }}'
-            GEMINI_API_KEY = '${{ secrets.GEMINI_API_KEY }}'
-            DISCORD_TOKEN = '${{ secrets.DISCORD_TOKEN }}'
-            DEBUG_ROOM_ID = '${{ secrets.DEBUG_ROOM_ID }}'
-            FREETALK1_ROOM_ID = '${{ secrets.FREETALK1_ROOM_ID }}'
-            FREETALK2_ROOM_ID = '${{ secrets.FREETALK2_ROOM_ID }}'
-            MADSISTERS_ROOM_ID = '${{ secrets.MADSISTERS_ROOM_ID }}'
-            SHYBOYS_ROOM_ID = '${{ secrets.SHYBOYS_ROOM_ID }}'
-            SHUTTLE_API_KEY = '${{ secrets.SHUTTLE_API_KEY }}'
-            EROGAKI_ROLE_ID = '${{ secrets.EROGAKI_ROLE_ID }}'
-            JAIL_MARK_ROLE_ID = '${{ secrets.JAIL_MARK_ROLE_ID }}'
-            JAIL_MAIN_ROLE_ID = '${{ secrets.JAIL_MAIN_ROLE_ID }}'
-            DISCORD_GUILD_ID = '${{ secrets.DISCORD_GUILD_ID }}'
-            COMMIT_HASH = '${{ env.COMMIT_HASH }}'
-            COMMIT_DATE = '${{ env.COMMIT_DATE }}'
-            DISABLED_COMMANDS = '${{ secrets.DISABLED_COMMANDS }}'
-            ROOMS_ID = '${{ secrets.ROOMS_ID }}'
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Set variables
+        run: |
+          railway variables set \
+            COMMIT_HASH='${{ env.COMMIT_HASH }}' \
+            COMMIT_DATE='${{ env.COMMIT_DATE }}'
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Deploy
+        run: railway up --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,7 @@ serenity = { version = "0.12.4", default-features = false, features = [
   "model",
   "chrono",
 ] }
-shuttle-runtime = "0.55.0"
-shuttle-serenity = "0.55.0"
-tokio = "1.45.1"
+tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.41"
 rand_distr = "0.5.1"
 strum = { version = "0.27.1", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /app
 
@@ -7,14 +9,10 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    cargo build --release
+RUN cargo build --release
 
 FROM debian:trixie-slim
 COPY --from=builder /app/target/release/udamanami /usr/local/bin/udamanami

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.87-bookworm AS builder
+
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/udamanami /usr/local/bin/udamanami
+
+CMD ["udamanami"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM rust:1.87-bookworm AS builder
-
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /app
+
+FROM chef AS planner
 COPY . .
-RUN cargo build --release
+RUN cargo chef prepare --recipe-path recipe.json
 
-FROM debian:bookworm-slim
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef cook --release --recipe-path recipe.json
 
-RUN apt-get update && apt-get install -y \
-    libssl3 \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo build --release
 
+FROM debian:trixie-slim
 COPY --from=builder /app/target/release/udamanami /usr/local/bin/udamanami
 
 CMD ["udamanami"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,1 @@
-cargo shuttle deploy --allow-dirty --no-test -idle-minutes 0
-cargo shuttle project statuscar
+railway up --detach

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,6 @@
+[build]
+dockerfilePath = "Dockerfile"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,11 @@ async fn main() -> anyhow::Result<()> {
 
     let jail_mark_role_id = env_var("JAIL_MARK_ROLE_ID")
         .map(|id| RoleId::from_str(&id).unwrap())
-        .unwrap();
+        .unwrap_or_default();
 
     let jail_main_role_id = env_var("JAIL_MAIN_ROLE_ID")
         .map(|id| RoleId::from_str(&id).unwrap())
-        .unwrap();
+        .unwrap_or_default();
 
     let commit_hash = env_var("COMMIT_HASH");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{convert::Into, str::FromStr};
+use std::{env, str::FromStr};
 
 use anyhow::Context as _;
 
@@ -6,27 +6,30 @@ use serenity::{
     model::id::{ChannelId, GuildId, RoleId},
     prelude::*,
 };
-use shuttle_runtime::SecretStore;
 
 use udamanami::ai;
 use udamanami::db::BotDatabase;
 use udamanami::Bot;
 
-#[shuttle_runtime::main]
-async fn serenity(
-    #[shuttle_runtime::Secrets] secrets: SecretStore,
-) -> shuttle_serenity::ShuttleSerenity {
-    // Get the discord token set in `Secrets.toml`
-    let token = secrets
-        .get("DISCORD_TOKEN")
-        .context("'DISCORD_TOKEN' was not found")?;
+fn env_var(key: &str) -> Option<String> {
+    env::var(key).ok()
+}
+
+fn env_var_required(key: &str) -> anyhow::Result<String> {
+    env::var(key).with_context(|| format!("'{key}' was not found"))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Get the discord token set in environment variables
+    let token = env_var_required("DISCORD_TOKEN")?;
 
     // Set gateway intents, which decides what events the bot will be notified about
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT
         | GatewayIntents::DIRECT_MESSAGES;
 
-    let channel_ids_new = secrets.get("ROOMS_ID").map_or(vec![], |rooms| {
+    let channel_ids_new = env_var("ROOMS_ID").map_or(vec![], |rooms| {
         rooms
             .split(',')
             .filter_map(|id| ChannelId::from_str(id.trim()).ok())
@@ -35,12 +38,12 @@ async fn serenity(
 
     // ↓ここからのコードは将来的に取り除きたい
     let channel_ids_old: Vec<ChannelId> = vec![
-        secrets.get("FREETALK1_ROOM_ID"),
-        secrets.get("FREETALK2_ROOM_ID"),
-        secrets.get("MADSISTERS_ROOM_ID"),
-        secrets.get("SHYBOYS_ROOM_ID"),
-        secrets.get("DEBUG_ROOM_ID"),
-        secrets.get("HOSPITAL_ROOM_ID"),
+        env_var("FREETALK1_ROOM_ID"),
+        env_var("FREETALK2_ROOM_ID"),
+        env_var("MADSISTERS_ROOM_ID"),
+        env_var("SHYBOYS_ROOM_ID"),
+        env_var("DEBUG_ROOM_ID"),
+        env_var("HOSPITAL_ROOM_ID"),
     ]
     .into_iter()
     .filter_map(|id| id.and_then(|id| ChannelId::from_str(&id).ok()))
@@ -53,13 +56,11 @@ async fn serenity(
     };
     // ↑ここまで
 
-    let debug_channel_id = secrets
-        .get("DEBUG_ROOM_ID")
+    let debug_channel_id = env_var("DEBUG_ROOM_ID")
         .map(|id| ChannelId::from_str(&id).unwrap())
         .unwrap_or_default();
 
-    let disabled_commands = secrets
-        .get("DISABLED_COMMANDS")
+    let disabled_commands = env_var("DISABLED_COMMANDS")
         .map(|commands| {
             commands
                 .split(',')
@@ -72,28 +73,26 @@ async fn serenity(
         .map(|s| s.as_str())
         .collect::<Vec<_>>();
 
-    let guild_id = secrets
-        .get("DISCORD_GUILD_ID")
+    let guild_id = env_var("DISCORD_GUILD_ID")
         .map(|id| GuildId::from_str(&id).unwrap())
         .unwrap();
 
-    let jail_mark_role_id = secrets
-        .get("JAIL_MARK_ROLE_ID")
+    let jail_mark_role_id = env_var("JAIL_MARK_ROLE_ID")
         .map(|id| RoleId::from_str(&id).unwrap())
         .unwrap();
 
-    let jail_main_role_id = secrets
-        .get("JAIL_MAIN_ROLE_ID")
+    let jail_main_role_id = env_var("JAIL_MAIN_ROLE_ID")
         .map(|id| RoleId::from_str(&id).unwrap())
         .unwrap();
 
-    let commit_hash = secrets.get("COMMIT_HASH");
+    let commit_hash = env_var("COMMIT_HASH");
 
-    let commit_date = secrets.get("COMMIT_DATE");
+    let commit_date = env_var("COMMIT_DATE");
 
-    let gemini = ai::GeminiAI::manami(&secrets.get("GEMINI_API_KEY").unwrap());
+    let gemini = ai::GeminiAI::manami(&env_var_required("GEMINI_API_KEY")?);
 
-    let database = BotDatabase::new("./db.sqlite").await?;
+    let database_path = env_var("DATABASE_PATH").unwrap_or_else(|| "./db.sqlite".to_owned());
+    let database = BotDatabase::new(&database_path).await?;
 
     let bot = Bot::new(
         channel_ids,
@@ -109,10 +108,12 @@ async fn serenity(
     )
     .await;
 
-    let client = Client::builder(&token, intents)
+    let mut client = Client::builder(&token, intents)
         .event_handler(bot)
         .await
         .expect("Err creating client");
 
-    Ok(client.into())
+    client.start().await?;
+
+    Ok(())
 }


### PR DESCRIPTION
## 概要
Shuttleが爆散したので代わりのデプロイ先としてRailwayを仮置きし、それ用の調整などをしました
これでDockerコンテナが動くところならどこでも動くようになったのではないかと思います たぶん

## 変更点
Shuttle関連のコードはほとんど全てClaude Codeに書き換えさせました
そこからDockerでちゃんと動くようにするために更に手で修正を加えました
Rust側を手で書き換えた部分としては、収監チャンネルIDがなくてもとりあえず動くようにするために`unwrap`を`unwrap_or_default`にしました 注意
また、いくつかの環境変数はGitHub secretsではなくデプロイ先で指定する必要があります これも注意
ついでにGitHub Actionsのバージョンも上げました
