### PR TITLE
Fix memory page out-of-bounds panic

### DIFF
--- a/app/src/commands/memory.rs
+++ b/app/src/commands/memory.rs
@@ -103,12 +103,17 @@ async fn list(sub_options: &[ResolvedOption<'_>], ctx: &CommandContext<'_>) -> S
         return "まだ何も記憶してないよ。".to_owned();
     }
 
-    let body = memories
+    let memories_string = memories
         .iter()
         .map(|m| format!("- `{}` {}", m.memory_id, m.title))
-        .collect::<Vec<_>>()[((page - 1) * 20)..(page * 20).min(memories.len())]
-        .join("\n");
-    format!("記憶の一覧だよ:\n{body}")
+        .collect::<Vec<_>>();
+    let body = memories_string
+        .get(((page - 1) * 20)..(page * 20).min(memories_string.len()));
+
+    match body {
+        Some(body_vec) => format!("記憶の一覧だよ:\n{}", body_vec.join("\n")),
+        None => String::from("そのページは範囲外だよ")
+    }
 }
 
 async fn get(sub_options: &[ResolvedOption<'_>], ctx: &CommandContext<'_>) -> String {


### PR DESCRIPTION
`/memory list` で範囲外のページを指定した時に panic を起こす問題を修正しました。