### PR TITLE
Fix regex not to capture empty commands

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -498,7 +498,7 @@ async fn guild_message(bot: &Bot, ctx: &Context, msg: &Message) {
     let is_debug_channel = msg.channel_id.get() == bot.debug_channel_id.get();
 
     // if message does not contains any command, respond with AI
-    let command_pattern = Regex::new(r"(?ms)(^!|まなみ(?:ちゃん)?)(.*)").unwrap();
+    let command_pattern = Regex::new(r"(?ms)(^!|まなみ(?:ちゃん)?)(.+)").unwrap();
     let input_string = match command_pattern.captures(&msg.content) {
         // コマンド部分を抽出
         Some(caps) => caps.get(2).unwrap().as_str().to_owned(),


### PR DESCRIPTION
通常の発言に command prefix (`!`) か 呼びかけ (「まなみ」) が含まれており直後に何も続かない場合、正規表現 `(.*)` では空の capture group を取ってしまい、直後の `unwrap()` で panic を起こしてしまう。結果的にそのメッセージには呼びかけが含まれているにも関わらずまなみは返答をしなくなる。
正規表現を `(.+)` に変えることでこの問題を解決。